### PR TITLE
freebsd compatibilty

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "image-type": "^4.1.0",
     "lodash.uniq": "^4.5.0",
     "ora": "^4.0.2",
-    "puppeteer": "^2.1.1",
+    "puppeteer": "plato79/puppeteer",
     "puppeteer-extra": "^3.1.9",
     "puppeteer-extra-plugin-devtools": "^2.2.8",
     "puppeteer-extra-plugin-stealth": "^2.4.9",


### PR DESCRIPTION
The `puppeteer` repository on my profile allows installing without any problem on FreeBSD based systems.

Although you'll need to use environment variable to skip downloading chrome and install it via pkg:

```
sudo pkg install chrome
setenv PUPPETEER_SKIP_DOWNLOAD true
```

There is still problem with sharp though.. vips included in FreeBSD is not compatible with sharp. It requires vips 8.9, but there is vips 8.8 included in FreeBSD.. You most probably need to compile it yourself. I'll look into this.