### PR TITLE
Feature: Add proxyServerCredentials config option

### DIFF
--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -78,7 +78,7 @@ export interface DevTools {
 
 export interface ProxyServerCredentials {
     /**
-    * Username for Proxy Server authentication
+    * Proxy Server address. This can include the port e.g '127.0.0.1:5005'
     */
     address: string,
     /**
@@ -185,7 +185,7 @@ export interface ConfigObject {
      */
     useChrome ?: boolean,
     /**
-     * If sent, adds a call to waPage.authenticate with those credentials. Must be used in conjuction with --proxy-server=PROXY_SERVER_URL flag on chromiumArgs.
+     * If sent, adds a call to waPage.authenticate with those credentials.
      */
     proxyServerCredentials?: ProxyServerCredentials,
     /**

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -76,7 +76,7 @@ export interface DevTools {
     pass : String
 }
 
-export interface ProxyServerConfigCredentials {
+export interface ProxyServerCredentials {
     /**
     * Username for Proxy Server authentication
     */
@@ -87,17 +87,6 @@ export interface ProxyServerConfigCredentials {
     password : String,        
 }
     
-export interface ProxyServerConfig {
-    /**
-    * Proxy Server URL 
-    */
-    url : String,
-    /**
-    * Credentials Object
-    */
-    credentials ?: ProxyServerConfigCredentials
-}
-
 export interface ConfigObject {
     /**
      * JSON object that is required to migrate a session from one instance to another or ot just restart an existing instance.
@@ -192,9 +181,9 @@ export interface ConfigObject {
      */
     useChrome ?: boolean,
     /**
-     * If sent, sets the --proxy-server flag on chromiumArgs. If sent with credentials, calls waPage.authenticate with those parameters. Please note this overrides any --proxy-server flag defined on chromiumArgs.
+     * If sent, adds a call to waPage.authenticate with those credentials. Must be used in conjuction with --proxy-server=PROXY_SERVER_URL flag on chromiumArgs.
      */
-    proxyServerConfig ?: ProxyServerConfig,
+    proxyServerCredentials?: ProxyServerCredentials,
     /**
      * If set, the program will try to recreate itself when the page crashes. You have to pass the function that you want called upon restart. Please note that when the page crashes you may miss some messages.
      * E.g:

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -76,6 +76,28 @@ export interface DevTools {
     pass : String
 }
 
+export interface ProxyServerConfigCredentials {
+    /**
+    * Username for Proxy Server authentication
+    */
+    username : String,
+    /**
+    * Password for Proxy Server authentication
+    */
+    password : String,        
+}
+    
+export interface ProxyServerConfig {
+    /**
+    * Proxy Server URL 
+    */
+    url : String,
+    /**
+    * Credentials Object
+    */
+    credentials ?: ProxyServerConfigCredentials
+}
+
 export interface ConfigObject {
     /**
      * JSON object that is required to migrate a session from one instance to another or ot just restart an existing instance.
@@ -169,6 +191,10 @@ export interface ConfigObject {
      * If true, the program will automatically try to detect the instance of chorme on the machine. Please note this overrides executablePath.
      */
     useChrome ?: boolean,
+    /**
+     * If sent, sets the --proxy-server flag on chromiumArgs. If sent with credentials, calls waPage.authenticate with those parameters. Please note this overrides any --proxy-server flag defined on chromiumArgs.
+     */
+    proxyServerConfig ?: ProxyServerConfig,
     /**
      * If set, the program will try to recreate itself when the page crashes. You have to pass the function that you want called upon restart. Please note that when the page crashes you may miss some messages.
      * E.g:

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -59,32 +59,36 @@ export enum WAState {
 };
 
 export interface SessionData {
-    WABrowserId ?: String,
-    WASecretBundle ?: String,
-    WAToken1 ?: String,
-    WAToken2 ?: String,
+    WABrowserId ?: string,
+    WASecretBundle ?: string,
+    WAToken1 ?: string,
+    WAToken2 ?: string,
 }
 
 export interface DevTools {
     /**
      * Username for devtools
      */
-    user : String,
+    user : string,
     /**
      * Password for devtools
      */
-    pass : String
+    pass : string
 }
 
 export interface ProxyServerCredentials {
     /**
     * Username for Proxy Server authentication
     */
-    username : String,
+    address: string,
+    /**
+    * Username for Proxy Server authentication
+    */
+    username : string,
     /**
     * Password for Proxy Server authentication
     */
-    password : String,        
+    password : string,        
 }
     
 export interface ConfigObject {

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -69,7 +69,7 @@ async function initBrowser(sessionId?: string, puppeteerConfigOverride:any={}) {
     puppeteerConfigOverride.executablePath = ChromeLauncher.Launcher.getInstallations()[0];
     // console.log('\nFound chrome', puppeteerConfigOverride.executablePath)
   }
-
+  if(puppeteerConfigOverride.proxyServerCredentials.server) puppeteerConfig.chromiumArgs.push(`--proxy-server=${puppeteerConfigOverride.proxyServerCredentials.server}`)
   const browser = await puppeteer.launch({
     headless: true,
     devtools: false,

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -69,7 +69,7 @@ async function initBrowser(sessionId?: string, puppeteerConfigOverride:any={}) {
     puppeteerConfigOverride.executablePath = ChromeLauncher.Launcher.getInstallations()[0];
     // console.log('\nFound chrome', puppeteerConfigOverride.executablePath)
   }
-  if(puppeteerConfigOverride.proxyServerCredentials.server) puppeteerConfig.chromiumArgs.push(`--proxy-server=${puppeteerConfigOverride.proxyServerCredentials.server}`)
+  if(puppeteerConfigOverride.proxyServerCredentials.address) puppeteerConfig.chromiumArgs.push(`--proxy-server=${puppeteerConfigOverride.proxyServerCredentials.address}`)
   const browser = await puppeteer.launch({
     headless: true,
     devtools: false,

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -14,6 +14,9 @@ let browser;
 export async function initWhatsapp(sessionId?: string, puppeteerConfigOverride?:any, customUserAgent?:string) {
   browser = await initBrowser(sessionId,puppeteerConfigOverride);
   const waPage = await getWhatsappPage(browser);
+  if (puppeteerConfigOverride.proxyServerCredentials) {
+    await waPage.authenticate(puppeteerConfigOverride.proxyServerCredentials);
+  }
   await waPage.setUserAgent(customUserAgent||useragent);
   await waPage.setViewport({
     width,


### PR DESCRIPTION
The proposal is to add the ability to set credentials to be used when connection to a proxy server (via **--proxy-server** flag).

If you wanna use it, for example, with Luminati (check this: https://luminati.io/integration/puppeteer), you will need to authenticate, even with the use of their proxy-manager... (in this case, you can pass and empty {} as proxyServerCredentials value)

E.g: 
```
create({
        sessionId: `mySessionId`,
        headless: true,
        chromiumArgs: ['--proxy-server=127.00.1:24000'],
        proxyServerCredentials: { username: 'myusername', password: 'mypassword' }
}).then(async (client) => {...})
```
Hope this can help someone else!

Regards