### PR TITLE
Improved getLastSeen

### DIFF
--- a/src/lib/wapi.js
+++ b/src/lib/wapi.js
@@ -2140,11 +2140,19 @@ window.WAPI._STICKERDUMP = async function (chatId) {
 
 
 window.WAPI.getLastSeen = async function (id) {
-    if(!Store.Chat.get(id)) return false;
-    let {presence} = Store.Chat.get(id)
-    await presence.subscribe();
-    return presence.chatstate.t;
-  }
+  return new Promise(function (resolve, reject) {
+    let presence = Store.Chat.get(id).presence;
+    if (presence.chatstate.t) {
+      resolve(presence.chatstate.t)
+    } else {
+      presence.on('change:chatstate.t', (data) => {
+        resolve(data.t)
+      });
+      setTimeout(() => resolve(false), 3000)
+      presence.subscribe()
+    }
+  });
+}
 
 window.WAPI.getUseHereString = async function() { 
     if (!window.l10n.localeStrings['en']){


### PR DESCRIPTION
Previous getLastSeen doesnt resolve to the last seen time when first called on a chat, because it waits only on subscribe(), which doesn't resolve after WP responds with the data.

On this version, if the last seen time is already loaded, it returns it, and if not, it subscribes to changes on the presence and waits for the `change:chatstate.t` event, which fires when the last seen is updated from WP.

If after 3 seconds theres no response, it resolves to false, to prevent it from never resolving when for example that number doesnt share the last seen time