### PR TITLE
Adjusting client.createGroup return type to match documentation. And …

### DIFF
--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -5,7 +5,7 @@ import { Message } from './model/message';
 import { default as axios, AxiosRequestConfig} from 'axios';
 import { ParticipantChangedEventModel } from './model/group-metadata';
 import { useragent, puppeteerConfig } from '../config/puppeteer.config'
-import { ConfigObject, STATE, LicenseType, Webhook } from './model';
+import { ConfigObject, STATE, LicenseType, Webhook, GroupCreationResponse } from './model';
 import { PageEvaluationTimeout, CustomError, ERROR_NAME, AddParticipantError  } from './model/errors';
 import PQueue, { DefaultAddOptions, Options } from 'p-queue';
 import { ev, Spin } from '../controllers/events';
@@ -2439,8 +2439,8 @@ public async getStatus(contactId: ContactId) : Promise<{
 
   /**
    * Create a group and add contacts to it
-   * 
-   * @param to group name: 'New group'
+   *
+   * @param groupName
    * @param contacts: A single contact id or an array of contact ids.
    * @returns Promise<GroupCreationResponse> :
    * ```javascript
@@ -2458,7 +2458,7 @@ public async getStatus(contactId: ContactId) : Promise<{
    * }
    * ```
    */
-  public async createGroup(groupName:string,contacts:ContactId|ContactId[]) : Promise<any> {
+  public async createGroup(groupName: string,contacts: ContactId | ContactId[]) : Promise<GroupCreationResponse> {
     return await this.pup(
       ({ groupName, contacts }) => WAPI.createGroup(groupName, contacts),
       { groupName, contacts }

--- a/src/api/model/aliases.ts
+++ b/src/api/model/aliases.ts
@@ -1,6 +1,10 @@
 /**
  * The suffix used to identify a non-group chat id
  */
+import { Participant } from './group-metadata';
+import { Chat } from './chat';
+import List = marked.Tokens.List;
+
 export type ChatServer = 'c.us';
 
 /**
@@ -105,3 +109,11 @@ export type Base64 = string;
  * Learn more here: https://www.w3schools.com/html/html_filepaths.asp
  */
 export type FilePath = string;
+
+export type GroupCreationResponse = {
+  status: number;
+  gid: NonSerializedId;
+  participants: [
+    { ContactId: any },
+  ]
+}


### PR DESCRIPTION
- [X] Creating GroupCreationResponse
- [X] Adjusting createGroup return type to match documentation
- [X] Adding param groupName to jsdoc

**Obs:**  I used any because I'm not certain about the return in:
```javascript
participants: [
   { '447777777777@c.us': [Object] },
   { '447444444444@c.us': [Object] }
  ]
 ```