### PR TITLE
remove useless installation instruction and fixes onButton

### DIFF
--- a/docs-source/getting-started/installation.md
+++ b/docs-source/getting-started/installation.md
@@ -54,7 +54,6 @@ Doing this saves time and memory.
 Some people report issues with running the program using the built in puppeteer chromium package. Use this to install dependencies and install chrome. After doing the following command you can use Chrome by setting `useChrome: true` in the config or with the `--use-chrome` flag with the CLI.
 
 ```bash
-> sudo apt install -y libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils libcups2 libxss1 libnss3-tools freetype2-demos libharfbuzz-dev ttf-freefont ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils libnss3 curl wget
 > wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 > sudo apt install ./google-chrome-stable_current_amd64.deb
 ```

--- a/src/api/Client.ts
+++ b/src/api/Client.ts
@@ -698,7 +698,7 @@ export class Client {
    * @param fn callback
    * @fires [[Message]]
    */
-   public async onButton(fn: (chat: Chat) => void) : Promise<Listener | boolean> {
+   public async onButton(fn: (message: Message) => void) : Promise<Listener | boolean> {
     return this.registerListener(SimpleListener.Button, fn);
   }
 


### PR DESCRIPTION
by doing
```bash
> wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
> sudo apt install ./google-chrome-stable_current_amd64.deb
```
will already install the package automatically, instead of doing it manually