### PR TITLE
Update puppeteer version

### DIFF
--- a/types-only/package.json
+++ b/types-only/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@open-wa/wa-automate-types-only",
-    "version": "4.26.0",
+    "version": "4.26.1",
     "description": "Types generated from the @open-wa/wa-automate package",
     "scripts": {
         "build": "tsc",


### PR DESCRIPTION
This change prevents Target closed errors when reading streams which were caused by ending the stream before IO.close returns.
This is a recurring error in my application.