### PR TITLE
Fix: Update Default Port from 8002 to 8080 on CLI Options

### DIFF
--- a/src/cli/cli-options.ts
+++ b/src/cli/cli-options.ts
@@ -45,10 +45,10 @@ Merge<Merge<{
 {
     name: 'port',
     alias: 'p',
-    default: 8002,
+    default: 8080,
     type: Number,
     typeLabel: '{blue {underline 8080}}',
-    description: "Set the port for the api. Default to 8002."
+    description: "Set the port for the api. Default to 8080."
 },
 {
     name: 'forcePort',


### PR DESCRIPTION
Based on analysis of documentation and code related to wa-automate, it was determined that there is no need for the default port to be set to 8002. This pull request updates the default port to 8080 to prevent confusion in the future.