### PR TITLE
Clean up unused dashboard TypeScript code

### DIFF
--- a/apps/dashboard-neo/src/components/app-sidebar.test.tsx
+++ b/apps/dashboard-neo/src/components/app-sidebar.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 
 // Mock dependencies
 vi.mock('@/lib/hooks/use-health', () => ({

--- a/apps/dashboard-neo/src/components/app-sidebar.tsx
+++ b/apps/dashboard-neo/src/components/app-sidebar.tsx
@@ -47,37 +47,6 @@ import {
   Bot,
 } from "lucide-react"
 
-const navItems = [
-  {
-    group: "Overview",
-    items: [
-      { title: "Session", href: "/", icon: <Zap size={18} /> },
-      { title: "Health", href: "/health", icon: <HeartPulse size={18} /> },
-      { title: "Events", href: "/events", icon: <Activity size={18} /> },
-    ],
-  },
-  {
-    group: "Developer",
-    items: [
-      { title: "API Docs", href: "/api-docs", icon: <BookOpen size={18} /> },
-      { title: "Playground", href: "/playground", icon: <FlaskConical size={18} /> },
-      { title: "Debug", href: "/debug", icon: <Bug size={18} /> },
-    ],
-  },
-  {
-    group: "Communication",
-    items: [
-      { title: "Chat", href: "/chat", icon: <MessageSquare size={18} /> },
-      { title: "Contacts", href: "/contacts", icon: <Contact size={18} /> },
-      { title: "Portal", href: "/portal", icon: <Tv size={18} /> },
-    ],
-  },
-]
-
-/**
- * Fetches the plugin manifest from the API server.
- * Returns empty array if the API is unreachable.
- */
 function usePluginManifest() {
   const [plugins, setPlugins] = useState<PluginManifestEntry[]>([])
 

--- a/apps/dashboard-neo/src/routes/-mcp.test.tsx
+++ b/apps/dashboard-neo/src/routes/-mcp.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
 
 // Mock dependencies
 vi.mock('@/lib/hooks/use-health', () => ({

--- a/apps/dashboard-neo/src/routes/mcp.tsx
+++ b/apps/dashboard-neo/src/routes/mcp.tsx
@@ -21,7 +21,7 @@ import { getApiUrl } from "@/lib/api-client"
 export const Route = createFileRoute("/mcp")({ component: McpPage })
 
 export function McpPage() {
-  const { mcpAvailable, mcpEnabled, mcpPath, loading } = useHealth()
+  const { mcpAvailable, mcpEnabled, mcpPath } = useHealth()
   const [copied, setCopied] = useState<string | null>(null)
 
   const baseUrl = getApiUrl()
@@ -280,7 +280,6 @@ function ConfigSnippet({
   icon,
   snippet,
   copied,
-  setCopied,
   copyId,
   copyToClipboard,
   instructions,


### PR DESCRIPTION
Ran `pnpm run typecheck` in `apps/dashboard-neo` and cleaned up several unused imports and variables reported by TypeScript.

Changes include:

* removing unused React imports in test files
* removing unused dashboard navigation configuration
* removing unused variables in MCP route logic

This helps reduce TypeScript noise and improves maintainability in the dashboard frontend.

The remaining typecheck failures are existing module-resolution/configuration issues unrelated to this cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Sidebar navigation now dynamically loads plugins from manifest API, automatically refreshing every 30 seconds
  * Plugins section displays conditionally, appearing only when plugins are available
  * Enhanced active-state routing logic for plugin navigation entries based on current path
  * Cleaned up unused imports and variables in test files and MCP page implementation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-wa/wa-automate-nodejs/pull/3334)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->