### PR TITLE
Release v5 alpha

### DIFF
--- a/.github/workflows/pr-docs-check.yml
+++ b/.github/workflows/pr-docs-check.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
 
       - name: Check release readiness
         id: checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release:
@@ -24,8 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -82,11 +82,12 @@ jobs:
         with:
           version: pnpm version-packages
           publish: pnpm publish-packages
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # ── Post-publish: Get version ────────────────────────────────
       - name: Get published version

--- a/integrations/chatwoot/package.json
+++ b/integrations/chatwoot/package.json
@@ -26,5 +26,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/integrations/cloudflare/package.json
+++ b/integrations/cloudflare/package.json
@@ -30,5 +30,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/integrations/s3/package.json
+++ b/integrations/s3/package.json
@@ -32,5 +32,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/integrations/webhook/package.json
+++ b/integrations/webhook/package.json
@@ -26,5 +26,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "repomix": "npx repomix@latest",
-    "publish-packages": "turbo run build --filter='!@open-wa/legacy' --filter='!@open-wa/legacy-documented' && changeset publish",
+    "publish-packages": "./tools/release/publish-packages.sh",
     "release-image": "node tools/release-image.js"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,5 +38,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/packages/cf-proxy/package.json
+++ b/packages/cf-proxy/package.json
@@ -15,5 +15,9 @@
     "@cloudflare/workers-types": "^4.20240320.1",
     "typescript": "^5.5.0",
     "wrangler": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,5 +44,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,5 +36,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -53,5 +53,9 @@
     "configuration",
     "zod",
     "cosmiconfig"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,5 +51,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/decrypt/package.json
+++ b/packages/decrypt/package.json
@@ -46,5 +46,9 @@
     "whatsapp",
     "decrypt",
     "media"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -30,5 +30,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/packages/driver-interface/package.json
+++ b/packages/driver-interface/package.json
@@ -1,25 +1,29 @@
 {
-    "name": "@open-wa/driver-interface",
-    "version": "5.0.0-alpha.1",
-    "description": "Browser driver abstraction interfaces for open-wa",
-    "main": "./dist/index.cjs",
-    "types": "./dist/index.d.cts",
-    "exports": {
-        ".": {
-            "require": "./dist/index.cjs",
-            "import": "./dist/index.cjs",
-            "types": "./dist/index.d.cts"
-        }
-    },
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "devDependencies": {
-        "typescript": "catalog:"
+  "name": "@open-wa/driver-interface",
+  "version": "5.0.0-alpha.1",
+  "description": "Browser driver abstraction interfaces for open-wa",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.cjs",
+      "types": "./dist/index.d.cts"
     }
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/driver-lightpanda/package.json
+++ b/packages/driver-lightpanda/package.json
@@ -1,43 +1,47 @@
 {
-    "name": "@open-wa/driver-lightpanda",
-    "version": "5.0.0-alpha.1",
-    "description": "Lightpanda browser driver for open-wa",
-    "main": "./dist/index.cjs",
-    "types": "./dist/index.d.cts",
-    "exports": {
-        ".": {
-            "require": "./dist/index.cjs",
-            "import": "./dist/index.cjs",
-            "types": "./dist/index.d.cts"
-        }
-    },
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src",
-        "test": "vitest run"
-    },
-    "dependencies": {
-        "@open-wa/driver-interface": "workspace:*"
-    },
-    "peerDependencies": {
-        "@lightpanda/browser": ">=0.1.0",
-        "puppeteer": ">=22.0.0"
-    },
-    "peerDependenciesMeta": {
-        "@lightpanda/browser": {
-            "optional": true
-        },
-        "puppeteer": {
-            "optional": true
-        }
-    },
-    "devDependencies": {
-        "@types/node": "catalog:",
-        "typescript": "catalog:",
-        "vitest": "catalog:"
-    },
-    "publishConfig": {
-        "access": "public"
+  "name": "@open-wa/driver-lightpanda",
+  "version": "5.0.0-alpha.1",
+  "description": "Lightpanda browser driver for open-wa",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.cjs",
+      "types": "./dist/index.d.cts"
     }
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@open-wa/driver-interface": "workspace:*"
+  },
+  "peerDependencies": {
+    "@lightpanda/browser": ">=0.1.0",
+    "puppeteer": ">=22.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lightpanda/browser": {
+      "optional": true
+    },
+    "puppeteer": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/driver-playwright/package.json
+++ b/packages/driver-playwright/package.json
@@ -1,32 +1,36 @@
 {
-    "name": "@open-wa/driver-playwright",
-    "version": "5.0.0-alpha.1",
-    "description": "Playwright driver implementation for open-wa",
-    "main": "./dist/index.cjs",
-    "types": "./dist/index.d.cts",
-    "exports": {
-        ".": {
-            "require": "./dist/index.cjs",
-            "import": "./dist/index.cjs",
-            "types": "./dist/index.d.cts"
-        }
-    },
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src",
-        "test": "vitest run"
-    },
-    "dependencies": {
-        "@open-wa/driver-interface": "workspace:*",
-        "playwright": "^1.41.0"
-    },
-    "devDependencies": {
-        "@types/node": "catalog:",
-        "typescript": "catalog:",
-        "vitest": "catalog:"
-    },
-    "publishConfig": {
-        "access": "public"
+  "name": "@open-wa/driver-playwright",
+  "version": "5.0.0-alpha.1",
+  "description": "Playwright driver implementation for open-wa",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.cjs",
+      "types": "./dist/index.d.cts"
     }
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@open-wa/driver-interface": "workspace:*",
+    "playwright": "^1.41.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/driver-puppeteer/package.json
+++ b/packages/driver-puppeteer/package.json
@@ -1,33 +1,37 @@
 {
-    "name": "@open-wa/driver-puppeteer",
-    "version": "5.0.0-alpha.1",
-    "description": "Puppeteer driver implementation for open-wa",
-    "main": "./dist/index.cjs",
-    "types": "./dist/index.d.cts",
-    "exports": {
-        ".": {
-            "require": "./dist/index.cjs",
-            "import": "./dist/index.cjs",
-            "types": "./dist/index.d.cts"
-        }
-    },
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src",
-        "test": "vitest run"
-    },
-    "dependencies": {
-        "@open-wa/driver-interface": "workspace:*",
-        "puppeteer": "catalog:",
-        "puppeteer-extra": "catalog:"
-    },
-    "devDependencies": {
-        "@types/node": "catalog:",
-        "typescript": "catalog:",
-        "vitest": "catalog:"
-    },
-    "publishConfig": {
-        "access": "public"
+  "name": "@open-wa/driver-puppeteer",
+  "version": "5.0.0-alpha.1",
+  "description": "Puppeteer driver implementation for open-wa",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.cjs",
+      "types": "./dist/index.d.cts"
     }
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@open-wa/driver-interface": "workspace:*",
+    "puppeteer": "catalog:",
+    "puppeteer-extra": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,28 +1,32 @@
 {
-    "name": "@open-wa/logger",
-    "version": "5.0.0",
-    "description": "Centralized logging and terminal UI for open-wa v5",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.cts",
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src",
-        "test": "vitest run --passWithNoTests"
-    },
-    "dependencies": {
-        "chalk": "^4.1.2",
-        "figlet": "^1.5.2",
-        "log-update": "^4.0.0",
-        "ora": "^5.4.1",
-        "winston": "^3.11.0",
-        "winston-transport": "^4.6.0",
-        "zod": "catalog:"
-    },
-    "devDependencies": {
-        "@types/figlet": "^1.5.8",
-        "@types/node": "catalog:",
-        "typescript": "catalog:",
-        "vitest": "catalog:"
-    }
+  "name": "@open-wa/logger",
+  "version": "5.0.0",
+  "description": "Centralized logging and terminal UI for open-wa v5",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.cts",
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "figlet": "^1.5.2",
+    "log-update": "^4.0.0",
+    "ora": "^5.4.1",
+    "winston": "^3.11.0",
+    "winston-transport": "^4.6.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/figlet": "^1.5.8",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -40,5 +40,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -33,5 +33,9 @@
     "plugin",
     "sdk",
     "whatsapp"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,86 +1,90 @@
 {
-    "name": "@open-wa/schema",
-    "version": "5.0.0-alpha.1",
-    "type": "module",
-    "description": "Zod-based schema definitions for open-wa",
-    "main": "./dist/index.cjs",
-    "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "require": {
-                "types": "./dist/index.d.cts",
-                "default": "./dist/index.cjs"
-            },
-            "import": {
-                "types": "./dist/index.d.mts",
-                "default": "./dist/index.mjs"
-            }
-        },
-        "./generated": {
-            "require": {
-                "types": "./dist/generated/index.d.cts",
-                "default": "./dist/generated/index.cjs"
-            },
-            "import": {
-                "types": "./dist/generated/index.d.mts",
-                "default": "./dist/generated/index.mjs"
-            }
-        },
-        "./implementor": {
-            "require": {
-                "types": "./dist/implementor.d.cts",
-                "default": "./dist/implementor.cjs"
-            },
-            "import": {
-                "types": "./dist/implementor.d.mts",
-                "default": "./dist/implementor.mjs"
-            }
-        },
-        "./methods": {
-            "require": {
-                "types": "./dist/methods/index.d.cts",
-                "default": "./dist/methods/index.cjs"
-            },
-            "import": {
-                "types": "./dist/methods/index.d.mts",
-                "default": "./dist/methods/index.mjs"
-            }
-        },
-        "./http-manifest": {
-            "require": {
-                "types": "./dist/http-manifest.d.cts",
-                "default": "./dist/http-manifest.cjs"
-            },
-            "import": {
-                "types": "./dist/http-manifest.d.mts",
-                "default": "./dist/http-manifest.mjs"
-            }
-        }
+  "name": "@open-wa/schema",
+  "version": "5.0.0-alpha.1",
+  "type": "module",
+  "description": "Zod-based schema definitions for open-wa",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     },
-    "scripts": {
-        "generate": "tsx scripts/gen-openapi.ts && tsx scripts/gen-types.ts && tsx scripts/gen-client-implementation.ts && tsx scripts/gen-client-reference-docs.ts",
-        "build": "pnpm generate && tsdown",
-        "dev": "tsdown --watch",
-        "lint": "oxlint src scripts",
-        "test": "vitest run",
-        "test:contracts": "pnpm generate && vitest run src/__tests__/*.contract.test.ts",
-        "verify": "tsx scripts/verify-v5-pipeline.ts",
-        "ci": "pnpm verify && pnpm test:contracts && pnpm build"
+    "./generated": {
+      "require": {
+        "types": "./dist/generated/index.d.cts",
+        "default": "./dist/generated/index.cjs"
+      },
+      "import": {
+        "types": "./dist/generated/index.d.mts",
+        "default": "./dist/generated/index.mjs"
+      }
     },
-    "dependencies": {
-        "@asteasolutions/zod-to-openapi": "^8.5.0",
-        "@open-wa/config": "workspace:*",
-        "@open-wa/utils": "workspace:*",
-        "zod": "catalog:",
-        "zod-to-json-schema": "^3.22.3"
+    "./implementor": {
+      "require": {
+        "types": "./dist/implementor.d.cts",
+        "default": "./dist/implementor.cjs"
+      },
+      "import": {
+        "types": "./dist/implementor.d.mts",
+        "default": "./dist/implementor.mjs"
+      }
     },
-    "devDependencies": {
-        "ts-node": "catalog:",
-        "typescript": "catalog:",
-        "vitest": "catalog:"
+    "./methods": {
+      "require": {
+        "types": "./dist/methods/index.d.cts",
+        "default": "./dist/methods/index.cjs"
+      },
+      "import": {
+        "types": "./dist/methods/index.d.mts",
+        "default": "./dist/methods/index.mjs"
+      }
     },
-    "publishConfig": {
-        "access": "public"
+    "./http-manifest": {
+      "require": {
+        "types": "./dist/http-manifest.d.cts",
+        "default": "./dist/http-manifest.cjs"
+      },
+      "import": {
+        "types": "./dist/http-manifest.d.mts",
+        "default": "./dist/http-manifest.mjs"
+      }
     }
+  },
+  "scripts": {
+    "generate": "tsx scripts/gen-openapi.ts && tsx scripts/gen-types.ts && tsx scripts/gen-client-implementation.ts && tsx scripts/gen-client-reference-docs.ts",
+    "build": "pnpm generate && tsdown",
+    "dev": "tsdown --watch",
+    "lint": "oxlint src scripts",
+    "test": "vitest run",
+    "test:contracts": "pnpm generate && vitest run src/__tests__/*.contract.test.ts",
+    "verify": "tsx scripts/verify-v5-pipeline.ts",
+    "ci": "pnpm verify && pnpm test:contracts && pnpm build"
+  },
+  "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.5.0",
+    "@open-wa/config": "workspace:*",
+    "@open-wa/utils": "workspace:*",
+    "zod": "catalog:",
+    "zod-to-json-schema": "^3.22.3"
+  },
+  "devDependencies": {
+    "ts-node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/screencaster/package.json
+++ b/packages/screencaster/package.json
@@ -1,58 +1,62 @@
 {
-    "name": "@open-wa/screencaster",
-    "version": "5.0.0-alpha.1",
-    "description": "Headless browser screencasting for open-wa — treeshakable server + client",
-    "type": "module",
-    "exports": {
-        "./server": {
-            "types": "./dist/server.d.mts",
-            "import": "./dist/server.mjs",
-            "require": "./dist/server.cjs"
-        },
-        "./client": {
-            "types": "./dist/client.d.mts",
-            "import": "./dist/client.mjs",
-            "require": "./dist/client.cjs"
-        },
-        "./types": {
-            "types": "./dist/types.d.mts",
-            "import": "./dist/types.mjs",
-            "require": "./dist/types.cjs"
-        }
+  "name": "@open-wa/screencaster",
+  "version": "5.0.0-alpha.1",
+  "description": "Headless browser screencasting for open-wa — treeshakable server + client",
+  "type": "module",
+  "exports": {
+    "./server": {
+      "types": "./dist/server.d.mts",
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.cjs"
     },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsdown --format cjs,esm",
-        "dev": "tsdown --format cjs,esm --watch",
-        "lint": "oxlint src",
-        "typecheck": "tsc --noEmit"
+    "./client": {
+      "types": "./dist/client.d.mts",
+      "import": "./dist/client.mjs",
+      "require": "./dist/client.cjs"
     },
-    "dependencies": {
-        "hono": "catalog:"
-    },
-    "peerDependencies": {
-        "@open-wa/driver-interface": "workspace:*"
-    },
-    "peerDependenciesMeta": {
-        "@open-wa/driver-interface": {
-            "optional": true
-        }
-    },
-    "devDependencies": {
-        "@open-wa/driver-interface": "workspace:*",
-        "@types/node": "catalog:",
-        "typescript": "catalog:"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "keywords": [
-        "open-wa",
-        "whatsapp",
-        "screencaster",
-        "cdp",
-        "headless"
-    ]
+    "./types": {
+      "types": "./dist/types.d.mts",
+      "import": "./dist/types.mjs",
+      "require": "./dist/types.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown --format cjs,esm",
+    "dev": "tsdown --format cjs,esm --watch",
+    "lint": "oxlint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "catalog:"
+  },
+  "peerDependencies": {
+    "@open-wa/driver-interface": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@open-wa/driver-interface": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@open-wa/driver-interface": "workspace:*",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "open-wa",
+    "whatsapp",
+    "screencaster",
+    "cdp",
+    "headless"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/session-sync/package.json
+++ b/packages/session-sync/package.json
@@ -1,25 +1,29 @@
 {
-    "name": "@open-wa/session-sync",
-    "version": "1.0.0",
-    "main": "dist/index.cjs",
-    "types": "dist/index.d.cts",
-    "scripts": {
-        "build": "tsdown src/index.ts --format cjs",
-        "dev": "tsdown src/index.ts --format cjs --watch",
-        "lint": "oxlint src",
-        "test": "vitest run --passWithNoTests"
-    },
-    "dependencies": {
-        "pico-s3": "^2.11.0",
-        "tar-fs": "^3.0.0",
-        "simple-zstd": "^1.4.1",
-        "chokidar": "^4.0.0",
-        "@open-wa/schema": "workspace:*"
-    },
-    "devDependencies": {
-        "typescript": "catalog:",
-        "vitest": "catalog:",
-        "@types/node": "catalog:",
-        "@types/tar-fs": "catalog:"
-    }
+  "name": "@open-wa/session-sync",
+  "version": "1.0.0",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.cts",
+  "scripts": {
+    "build": "tsdown src/index.ts --format cjs",
+    "dev": "tsdown src/index.ts --format cjs --watch",
+    "lint": "oxlint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "pico-s3": "^2.11.0",
+    "tar-fs": "^3.0.0",
+    "simple-zstd": "^1.4.1",
+    "chokidar": "^4.0.0",
+    "@open-wa/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/tar-fs": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,28 +1,32 @@
 {
-    "name": "@open-wa/ui-components",
-    "version": "1.0.0",
-    "main": "src/index.ts",
-    "types": "src/index.ts",
-    "dependencies": {
-        "@radix-ui/react-avatar": "^1.1.11",
-        "@radix-ui/react-dialog": "^1.1.15",
-        "@radix-ui/react-label": "^2.1.8",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@radix-ui/react-toast": "^1.2.15",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "catalog:",
-        "lucide-react": "catalog:",
-        "react": "catalog:",
-        "react-dom": "catalog:",
-        "tailwind-merge": "catalog:",
-        "tailwindcss": "catalog:",
-        "tailwindcss-animate": "^1.0.7"
-    },
-    "devDependencies": {
-        "@types/react": "catalog:",
-        "@types/react-dom": "catalog:",
-        "autoprefixer": "catalog:",
-        "postcss": "catalog:",
-        "typescript": "catalog:"
-    }
+  "name": "@open-wa/ui-components",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toast": "^1.2.15",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "catalog:",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwind-merge": "catalog:",
+    "tailwindcss": "catalog:",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "autoprefixer": "catalog:",
+    "postcss": "catalog:",
+    "typescript": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,43 +1,47 @@
 {
-    "name": "@open-wa/utils",
-    "version": "5.0.0-alpha.1",
-    "description": "Shared utility functions for open-wa",
-    "main": "./dist/index.cjs",
-    "module": "./dist/index.mjs",
-    "types": "./dist/index.d.mts",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs",
-            "require": "./dist/index.cjs"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsdown",
-        "dev": "tsdown --watch",
-        "lint": "oxlint src",
-        "typecheck": "tsc --noEmit"
-    },
-    "dependencies": {
-        "json5": "^2.2.3",
-        "pidtree": "^0.6.0",
-        "pidusage": "^3.0.2"
-    },
-    "devDependencies": {
-        "@types/node": "catalog:",
-        "@types/pidusage": "^2.0.5",
-        "typescript": "catalog:"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "keywords": [
-        "open-wa",
-        "whatsapp",
-        "utils"
-    ]
+  "name": "@open-wa/utils",
+  "version": "5.0.0-alpha.1",
+  "description": "Shared utility functions for open-wa",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint": "oxlint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "json5": "^2.2.3",
+    "pidtree": "^0.6.0",
+    "pidusage": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/pidusage": "^2.0.5",
+    "typescript": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "open-wa",
+    "whatsapp",
+    "utils"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
+  }
 }

--- a/packages/wa-automate/package.json
+++ b/packages/wa-automate/package.json
@@ -37,5 +37,9 @@
   "devDependencies": {
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-wa/wa-automate-nodejs.git"
   }
 }

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -4,7 +4,7 @@ Scripts for testing and executing the `@open-wa` release pipeline.
 
 ## Quick Start: Dry Run
 
-Test the entire release pipeline locally before going live on npm:
+Test the entire release pipeline locally before going live on npmjs and GitHub Packages:
 
 ```bash
 # Run the full dry run (build → publish to Verdaccio → generate notes → verify)
@@ -30,14 +30,29 @@ Full pipeline orchestrator. Starts a local Verdaccio registry, builds all packag
 
 **Options:**
 
-| Flag | Description |
-|---|---|
-| `--skip-build` | Skip `turbo build` (use existing `dist/`) |
-| `--skip-image` | Skip release image generation |
-| `--skip-install` | Skip test-install verification |
-| `--keep-verdaccio` | Keep Verdaccio running after the script exits |
-| `--port PORT` | Verdaccio port (default: 4873) |
-| `--bump TYPE` | Version bump type: `patch` / `minor` / `major` |
+| Flag               | Description                                    |
+| ------------------ | ---------------------------------------------- |
+| `--skip-build`     | Skip `turbo build` (use existing `dist/`)      |
+| `--skip-image`     | Skip release image generation                  |
+| `--skip-install`   | Skip test-install verification                 |
+| `--keep-verdaccio` | Keep Verdaccio running after the script exits  |
+| `--port PORT`      | Verdaccio port (default: 4873)                 |
+| `--bump TYPE`      | Version bump type: `patch` / `minor` / `major` |
+
+### `publish-packages.sh`
+
+CI publish wrapper used by `pnpm publish-packages`. It builds once with `pnpm build`, then publishes changed packages through Changesets alpha prerelease mode. The script never edits the project `.npmrc`; it creates temporary npmrc files and deletes them on exit.
+
+Publish order:
+
+1. npmjs, when `NPM_TOKEN` is set.
+2. GitHub Packages, when `GITHUB_TOKEN` is set.
+
+GitHub Packages uses the `@open-wa` scope registry (`https://npm.pkg.github.com`) and `--no-git-tag` when the installed Changesets CLI supports it, so the second registry publish does not try to create the same git tags again. This repo is already in Changesets pre mode with the `alpha` tag, so no one needs to switch registry settings by hand. The installed Changesets CLI rejects an explicit `--tag alpha` while pre mode is active; the script lets `.changeset/pre.json` provide the alpha tag in that case.
+
+```bash
+pnpm publish-packages
+```
 
 ### `generate-notes.ts`
 
@@ -80,20 +95,24 @@ Triggered on push to the `release` branch. Flow:
 
 1. Detect version bump from merged PR labels (`bump:major`, `bump:minor`, or default `patch`)
 2. Auto-create changeset if none exists
-3. Run `changesets/action` to version and publish
+3. Run `changesets/action` to version and dual-publish to npmjs and GitHub Packages through `pnpm publish-packages`
 4. Generate AI release notes (Gemini)
 5. Generate release image (Puppeteer)
 6. Create GitHub Release with notes + image
 7. Post to Discord
 
-**Required secrets:**
-- `NPM_TOKEN` — npm publish token
+**Required secrets and permissions:**
+
+- `NPM_TOKEN` — npmjs publish token with write access to `@open-wa/*`
+- `GITHUB_TOKEN` — built in to GitHub Actions; used for GitHub Packages
+- `packages: write` — required workflow permission for GitHub Packages publish
 - `GOOGLE_API_KEY` — Gemini API key for release notes
 - `DISCORD_WEBHOOK_URL` — Discord webhook for notifications
 
 ### PR Docs Check (`pr-docs-check.yml`)
 
 Runs on PRs targeting `release`. Posts a checklist comment checking:
+
 - Changeset presence
 - Version bump label
 - README/description/exports for changed packages
@@ -120,4 +139,4 @@ main ─────────────────────────
 1. All development happens on `main`
 2. When ready to release, merge `main` → `release` via PR
 3. Add `bump:minor` or `bump:major` label to the PR if needed
-4. Merge triggers the release workflow
+4. Merge triggers the release workflow; `pnpm publish-packages` handles npmjs and GitHub Packages without manual registry switching

--- a/tools/release/V5_RELEASE_CHECKLIST.md
+++ b/tools/release/V5_RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # @open-wa v5.0.0 — Pre-Release Checklist
 
-> **Purpose**: Walk through every item before publishing v5 to npm. Each section has a ✅/❌ status. Fix all ❌ (blockers) and decide on ⚠️ (warnings) before releasing.
+> **Purpose**: Walk through every item before publishing v5 to npmjs and GitHub Packages. Each section has a ✅/❌ status. Fix all ❌ (blockers) and decide on ⚠️ (warnings) before releasing.
 >
 > **How to use**: A reviewer (human or AI) should go through each section, run the listed commands, and check off items as they pass.
 
@@ -8,7 +8,7 @@
 
 ## 1. 📦 Package Metadata (npm DX)
 
-Every public package needs these fields in `package.json` for a good npm listing.
+Every public package needs these fields in `package.json` for a good npmjs and GitHub Packages listing.
 
 > [!IMPORTANT]
 > The project license is **Hippocratic + Do Not Harm (H-DNH) Version 1.1** as defined in `/LICENSE.md`. All packages MUST use `"license": "H-DNH V1.0"` in their `package.json`.
@@ -21,11 +21,11 @@ Every public package needs these fields in `package.json` for a good npm listing
 
 ### 1a. `description` — what shows on npmjs.com search results
 
-| Status | Package |
-|--------|---------|
-| ❌ | @open-wa/session-sync |
-| ❌ | @open-wa/ui-components |
-| ✅ | All other 24 public packages |
+| Status | Package                      |
+| ------ | ---------------------------- |
+| ❌     | @open-wa/session-sync        |
+| ❌     | @open-wa/ui-components       |
+| ✅     | All other 24 public packages |
 
 **Fix**: Add `"description"` to `session-sync/package.json` and `ui-components/package.json`.
 
@@ -33,17 +33,18 @@ Every public package needs these fields in `package.json` for a good npm listing
 
 ### 1b. `exports` — proper ESM/CJS entry points
 
-| Status | Package |
-|--------|---------|
-| ❌ | @open-wa/logger |
-| ❌ | @open-wa/orchestrator |
-| ❌ | @open-wa/session-sync |
-| ❌ | @open-wa/ui-components |
-| ❌ | @open-wa/wa-automate |
+| Status | Package                |
+| ------ | ---------------------- |
+| ❌     | @open-wa/logger        |
+| ❌     | @open-wa/orchestrator  |
+| ❌     | @open-wa/session-sync  |
+| ❌     | @open-wa/ui-components |
+| ❌     | @open-wa/wa-automate   |
 
 **Why it matters**: Without `exports`, bundlers and TypeScript `moduleResolution: "bundler"` can't resolve the package correctly. Users get red squiggles in their IDE.
 
 **Fix**: Add an `"exports"` field pointing to the built entry file(s). Example:
+
 ```json
 "exports": {
   ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" }
@@ -54,10 +55,10 @@ Every public package needs these fields in `package.json` for a good npm listing
 
 ### 1c. `types` — TypeScript type declarations
 
-| Status | Package |
-|--------|---------|
-| ❌ | @open-wa/plugin-sdk |
-| ❌ | @open-wa/screencaster |
+| Status | Package               |
+| ------ | --------------------- |
+| ❌     | @open-wa/plugin-sdk   |
+| ❌     | @open-wa/screencaster |
 
 **Fix**: Add `"types"` field or include `"types"` in the `"exports"` map.
 
@@ -68,17 +69,18 @@ Every public package needs these fields in `package.json` for a good npm listing
 > [!IMPORTANT]
 > Every package MUST have `"license": "H-DNH V1.0"` matching the root `LICENSE.md` (Hippocratic + Do Not Harm Version 1.1).
 
-| Status | Package | Current |
-|--------|---------|---------|
-| ✅ | @open-wa/hyperemitter | Apache-2.0 (own license — OK) |
-| ✅ | @open-wa/plugin-sdk | H-DNH V1.0 |
-| ✅ | @open-wa/socket-client | H-DNH V1.0 |
-| ✅ | @open-wa/wa-automate-types-only | H-DNH V1.0 |
-| ❌ | **All other 22 public packages** | MISSING |
+| Status | Package                          | Current                       |
+| ------ | -------------------------------- | ----------------------------- |
+| ✅     | @open-wa/hyperemitter            | Apache-2.0 (own license — OK) |
+| ✅     | @open-wa/plugin-sdk              | H-DNH V1.0                    |
+| ✅     | @open-wa/socket-client           | H-DNH V1.0                    |
+| ✅     | @open-wa/wa-automate-types-only  | H-DNH V1.0                    |
+| ❌     | **All other 22 public packages** | MISSING                       |
 
-**Why it matters**: npm shows "UNLICENSED" on the package page. Corporate users may be blocked from installing. GitHub shows a warning.
+**Why it matters**: npmjs shows "UNLICENSED" on the package page. Corporate users may be blocked from installing. GitHub shows a warning.
 
 **Fix** — batch script:
+
 ```bash
 for pkg in packages/*/package.json; do
   node -e "
@@ -95,44 +97,26 @@ done
 
 ---
 
-### 1e. `repository` — links npm page back to GitHub
+### 1e. `repository` — links package pages back to GitHub
 
-| Status | Package |
-|--------|---------|
-| ✅ | @open-wa/socket-client |
-| ✅ | @open-wa/wa-automate-types-only |
-| ❌ | **All other 24 public packages** |
+| Status | Package                |
+| ------ | ---------------------- |
+| ✅     | All 28 public packages |
 
-**Fix** — batch script:
-```bash
-for dir in packages/*/; do
-  pkg="$dir/package.json"
-  [ -f "$pkg" ] || continue
-  dirname=$(basename "$dir")
-  node -e "
-    const fs=require('fs');
-    const p=JSON.parse(fs.readFileSync('$pkg','utf8'));
-    if(!p.repository && !p.private){
-      p.repository={type:'git',url:'https://github.com/open-wa/wa-automate-nodejs',directory:'packages/$dirname'};
-      fs.writeFileSync('$pkg',JSON.stringify(p,null,2)+'\n');
-      console.log('✅ Added repository to '+p.name);
-    }
-  "
-done
-```
+All public packages under `packages/*` and `integrations/*` now have a `repository` field. Most point to `https://github.com/open-wa/wa-automate-nodejs.git`; package-specific repositories such as `@open-wa/socket-client`, `@open-wa/node-red`, and `@open-wa/wa-automate-types-only` keep their existing values.
 
 ---
 
 ## 2. 📝 README Files
 
-Only **3 out of 26** public packages have a README. npm renders the README as the package homepage — a missing README means users see a blank page.
+Only **3 out of 26** public packages have a README. npmjs and GitHub Packages render the README as the package homepage — a missing README means users see a blank page.
 
-| Status | Package |
-|--------|---------|
-| ✅ | hyperemitter |
-| ✅ | orchestrator |
-| ✅ | socket-client |
-| ❌ | **All other 23 public packages** |
+| Status | Package                          |
+| ------ | -------------------------------- |
+| ✅     | hyperemitter                     |
+| ✅     | orchestrator                     |
+| ✅     | socket-client                    |
+| ❌     | **All other 23 public packages** |
 
 ### Priority READMEs (MUST have before release)
 
@@ -203,10 +187,10 @@ curl -s http://localhost:3000/sitemap.xml | grep -i "package\|api\|guide"
 
 ## 4. 🔨 Build Output
 
-| Status | Package | Notes |
-|--------|---------|-------|
-| ⚠️ | ui-components | No `dist/` — must build before publish |
-| ✅ | **All other 25 public packages** | Have `dist/` |
+| Status | Package                          | Notes                                  |
+| ------ | -------------------------------- | -------------------------------------- |
+| ⚠️     | ui-components                    | No `dist/` — must build before publish |
+| ✅     | **All other 25 public packages** | Have `dist/`                           |
 
 **Note**: `cf-proxy` is now private and excluded from releases.
 
@@ -261,11 +245,15 @@ cat .changeset/config.json
 
 ## 8. 🔐 Secrets & CI
 
-Verify these exist in **GitHub repo Settings → Secrets**:
+Verify these exist in **GitHub repo Settings → Secrets** and workflow permissions:
 
-- [ ] `NPM_TOKEN` — npm publish token with write access to `@open-wa/*`
+- [ ] `NPM_TOKEN` — npmjs publish token with write access to `@open-wa/*`
+- [ ] `GITHUB_TOKEN` — built in to GitHub Actions; no repo secret is needed
+- [ ] `packages: write` — set in `.github/workflows/release.yml` for GitHub Packages publishing
 - [ ] `GOOGLE_API_KEY` — Gemini API key for release notes
 - [ ] `DISCORD_WEBHOOK_URL` — Discord channel webhook
+
+Release publishing should use `pnpm publish-packages`, not manual registry switching. The script builds once, publishes changed packages to npmjs when `NPM_TOKEN` exists, then publishes the same changed `@open-wa/*` packages to GitHub Packages when `GITHUB_TOKEN` exists. It uses temporary npmrc files only, so the root `.npmrc` stays pnpm-only. `.changeset/pre.json` supplies the `alpha` prerelease tag while Changesets pre mode is active.
 
 ---
 
@@ -299,7 +287,7 @@ Verify the following from their perspective:
 - [ ] Package installs without peer dependency warnings
 - [ ] Main export works: `import { create } from '@open-wa/wa-automate'` (or the actual entry)
 - [ ] TypeScript autocomplete works in VS Code (hover over imports, check types)
-- [ ] npmjs.com/package/@open-wa/wa-automate shows: description, README, license badge, repository link, correct version
+- [ ] npmjs.com/package/@open-wa/wa-automate and the GitHub Packages page show: description, README, license badge, repository link, correct version
 
 ---
 
@@ -317,23 +305,22 @@ rm -f .changeset/lively-waves-calm.md     # test changeset
 
 ## Severity Guide
 
-| Icon | Meaning | Action |
-|------|---------|--------|
-| ❌ | **Blocker** — must fix before release | Fix immediately |
-| ⚠️ | **Warning** — acceptable for alpha, fix before stable | Track in issue |
-| ✅ | **Pass** | No action needed |
+| Icon | Meaning                                               | Action           |
+| ---- | ----------------------------------------------------- | ---------------- |
+| ❌   | **Blocker** — must fix before release                 | Fix immediately  |
+| ⚠️   | **Warning** — acceptable for alpha, fix before stable | Track in issue   |
+| ✅   | **Pass**                                              | No action needed |
 
 ---
 
 ## Summary of Blockers
 
-| # | Issue | Impact | Fix Effort |
-|---|-------|--------|------------|
-| 1 | **License field missing** on 22 packages | npm shows "UNLICENSED" | 🟢 Batch script (1 min) |
-| 2 | **Repository field missing** on 24 packages | npm can't link to GitHub | 🟢 Batch script (1 min) |
-| 3 | **README missing** on 23 packages | Blank npm homepage | 🟡 Template + customise top 4 |
-| 4 | **`exports` field missing** on 5 packages | Bundler/TS resolution broken | 🟡 Manual per-package |
-| 5 | **`description` missing** on 2 packages | Blank on npm search | 🟢 Quick edit |
-| 6 | **`types` missing** on 2 packages | No autocomplete | 🟡 Check build output |
-| 7 | **`ui-components` no dist/** | Publish will fail | 🟡 Add build or mark private |
-| 8 | **Docs coverage** unclear | Users can't find documentation | 🟡 Audit docs site |
+| #   | Issue                                     | Impact                         | Fix Effort                    |
+| --- | ----------------------------------------- | ------------------------------ | ----------------------------- |
+| 1   | **License field missing** on 22 packages  | npm shows "UNLICENSED"         | 🟢 Batch script (1 min)       |
+| 3   | **README missing** on 23 packages         | Blank npm homepage             | 🟡 Template + customise top 4 |
+| 4   | **`exports` field missing** on 5 packages | Bundler/TS resolution broken   | 🟡 Manual per-package         |
+| 5   | **`description` missing** on 2 packages   | Blank on npm search            | 🟢 Quick edit                 |
+| 6   | **`types` missing** on 2 packages         | No autocomplete                | 🟡 Check build output         |
+| 7   | **`ui-components` no dist/**              | Publish will fail              | 🟡 Add build or mark private  |
+| 8   | **Docs coverage** unclear                 | Users can't find documentation | 🟡 Audit docs site            |

--- a/tools/release/ensure-changeset.ts
+++ b/tools/release/ensure-changeset.ts
@@ -104,11 +104,11 @@ function getCommitSummary(): string {
 function generateChangesetId(): string {
   const adjectives = [
     "brave", "calm", "eager", "fair", "gentle", "happy", "keen",
-    "lively", "neat", "polite", "quick", "sharp", "swift", "wise",
+    "lively", "neat", "polite", "quick", "sharp", "swift", "wise", "silly"
   ];
   const nouns = [
     "foxes", "hawks", "lions", "pandas", "ravens", "tides",
-    "waves", "winds", "wolves", "zebras",
+    "waves", "winds", "wolves", "zebras", "camels"
   ];
   const pick = <T>(arr: T[]) => arr[Math.floor(Math.random() * arr.length)];
   return `${pick(adjectives)}-${pick(nouns)}-${pick(adjectives)}`;

--- a/tools/release/publish-packages.sh
+++ b/tools/release/publish-packages.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+temp_npmrc_files=()
+
+cleanup() {
+  for npmrc_file in "${temp_npmrc_files[@]:-}"; do
+    if [[ -n "${npmrc_file}" && -f "${npmrc_file}" ]]; then
+      rm -f "${npmrc_file}"
+    fi
+  done
+}
+trap cleanup EXIT
+
+create_npmjs_npmrc() {
+  npmjs_npmrc="$(mktemp "${TMPDIR:-/tmp}/open-wa-npmjs.XXXXXX.npmrc")"
+  temp_npmrc_files+=("${npmjs_npmrc}")
+  {
+    printf '%s\n' 'registry=https://registry.npmjs.org/'
+    printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}'
+  } > "${npmjs_npmrc}"
+}
+
+create_github_npmrc() {
+  github_npmrc="$(mktemp "${TMPDIR:-/tmp}/open-wa-github.XXXXXX.npmrc")"
+  temp_npmrc_files+=("${github_npmrc}")
+  {
+    printf '%s\n' '@open-wa:registry=https://npm.pkg.github.com'
+    printf '%s\n' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}'
+  } > "${github_npmrc}"
+}
+
+changeset_help_mentions_no_git_tag() {
+  pnpm exec changeset --help 2>/dev/null | grep -q -- '--no-git-tag'
+}
+
+changeset_pre_mode_tag() {
+  node -e "const fs=require('fs'); const p='.changeset/pre.json'; if (!fs.existsSync(p)) process.exit(1); const data=JSON.parse(fs.readFileSync(p,'utf8')); if (data.mode === 'pre' && data.tag) process.stdout.write(data.tag); else process.exit(1);" 2>/dev/null || true
+}
+
+set_publish_args_for_current_pre_mode() {
+  local pre_tag
+  pre_tag="$(changeset_pre_mode_tag)"
+
+  if [[ "${pre_tag}" == "alpha" ]]; then
+    npm_publish_args=(publish)
+    return
+  fi
+
+  npm_publish_args=(publish --tag alpha)
+}
+
+run_changeset_publish() {
+  local npmrc_file="$1"
+  local token_value="$2"
+  shift 2
+
+  env \
+    NPM_CONFIG_USERCONFIG="${npmrc_file}" \
+    npm_config_userconfig="${npmrc_file}" \
+    NODE_AUTH_TOKEN="${token_value}" \
+    pnpm exec changeset "$@"
+}
+
+printf '%s\n' 'Building packages once before publishing...'
+pnpm build
+
+npm_publish_args=()
+set_publish_args_for_current_pre_mode
+if [[ "${#npm_publish_args[@]}" -eq 1 ]]; then
+  printf '%s\n' 'Changesets pre mode is already set to alpha; publishing without --tag alpha because this installed CLI rejects explicit --tag in pre mode.'
+fi
+
+if [[ -n "${NPM_TOKEN:-}" ]]; then
+  create_npmjs_npmrc
+  printf '%s\n' 'Publishing changed packages to npmjs with the alpha dist tag...'
+  run_changeset_publish "${npmjs_npmrc}" "${NPM_TOKEN}" "${npm_publish_args[@]}"
+else
+  printf '%s\n' 'Skipping npmjs publish: NPM_TOKEN is not set.'
+fi
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  create_github_npmrc
+  github_publish_args=("${npm_publish_args[@]}")
+
+  if changeset_help_mentions_no_git_tag; then
+    github_publish_args+=(--no-git-tag)
+    printf '%s\n' 'Publishing changed packages to GitHub Packages without creating duplicate git tags...'
+  else
+    printf '%s\n' 'Publishing changed packages to GitHub Packages. This installed Changesets CLI does not advertise --no-git-tag, so duplicate git tag creation cannot be disabled.'
+  fi
+
+  run_changeset_publish "${github_npmrc}" "${GITHUB_TOKEN}" "${github_publish_args[@]}"
+else
+  printf '%s\n' 'Skipping GitHub Packages publish: GITHUB_TOKEN is not set.'
+fi


### PR DESCRIPTION
## Summary

Release the current v5 alpha line from `master` into the new `release` branch. The `release` branch was created from `2418de582` so this PR carries the current release automation commit while the description below summarizes the full product delta from the last stable v4 tag to this v5 alpha.

## Changelog from v4.76.0 to v5 alpha

Compared range: `4.76.0..master` (`252` commits).

### Architecture and packaging
- Moved the project from the v4 single-package shape into a pnpm/Turbo monorepo.
- Split runtime surfaces into focused `@open-wa/*` packages including `core`, `wa-automate`, `api`, `client`, `schema`, `config`, `domain`, `utils`, `logger`, browser drivers, integrations, and support packages.
- Added Changesets-based versioning, fixed package grouping, prerelease alpha mode, release tooling, and dual-registry publishing support for npmjs plus GitHub Packages.

### Runtime and API
- Added the v5 Easy API server package and reusable API middleware.
- Reworked the runtime around typed schema manifests, generated OpenAPI/Postman output, health routes, debug/meta routes, API-key middleware, rate limiting, and runtime method invocation.
- Added session readiness and recovery work, including session health telemetry and stronger post-auth readiness handling.

### Client and transport
- Modernized the client facade with method modules, runtime surface tests, listener handling, and event management.
- Replaced legacy Socket.IO transport paths with HTTP commands plus Server-Sent Events for runtime events.
- Added a refreshed socket client and tunnel socket client with reconnect-focused transport behavior.

### Browser drivers and core runtime
- Added driver abstraction packages for Puppeteer, Playwright, and Lightpanda.
- Reworked core transport, injection control, patch lifecycle, script loading, runtime listener surface, and bootstrap validation.
- Added unit and E2E coverage around transport launch config, plugin host behavior, injection, runtime events, and readiness.

### Plugins and integrations
- Added `@open-wa/plugin-sdk` with plugin factories and type contracts.
- Added or migrated integrations for Webhook, Chatwoot, S3, Cloudflare, and Node-RED.
- Added Cloudflare session tunnel/proxy work for remote session access.

### MCP and AI tooling
- Added the hosted MCP package and Easy API adapter.
- Added AI agent discovery routes and docs surfaces for MCP/client integration.
- Added MCP health and dashboard navigation support.

### Dashboard and docs
- Added the next-generation dashboard app and embedded API docs experience.
- Added health, contacts, connection, demo launch, and screencast-related dashboard surfaces.
- Rebuilt the docs site with v5 alpha guidance, workspace/package references, integration guides, API explorer, generated OpenAPI docs, mascot assets, and clearer getting-started paths.

### Release readiness
- Added package repository metadata for GitHub Packages linking.
- Added `tools/release/publish-packages.sh` so CI can build once and publish changed alpha packages to npmjs and GitHub Packages without manual registry switching.
- Updated release documentation and checklist for dual-registry alpha publishing.

## Release notes

- This is an alpha release line. Changesets is already in prerelease mode with `tag: alpha`; do not pass `--tag alpha` manually and do not run `changeset pre exit` for this release.
- Publishing should happen through the release workflow using `pnpm publish-packages`.
- Required release setup: `NPM_TOKEN` repo secret for npmjs; built-in `GITHUB_TOKEN` with `packages: write` for GitHub Packages.

## Validation already run locally

- `git diff --check`
- `bash -n tools/release/publish-packages.sh`
- JSON parse check for package/release manifests
- public package repository metadata check
- Prettier check on changed JSON/Markdown/YAML files
- no-token `pnpm publish-packages` dry run: build completed, publishes skipped because tokens were unset

## After merge

Merging into `release` should trigger the release workflow. If Changesets opens a version PR, merge that PR into `release`; the following workflow run should publish the alpha packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized package metadata across all packages by adding repository information to package registries.
  * Normalized JSON formatting and indentation across package manifests.

* **Documentation**
  * Enhanced release process documentation with clearer dual-registry publishing instructions and required permissions.
  * Updated release checklist with improved package verification guidance.

* **Build & Release**
  * Improved CI/CD workflow with enhanced permissions and environment configuration for dual-registry publishing.
  * Added publishing automation script to streamline release process across npm and GitHub Packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-wa/wa-automate-nodejs/pull/3344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->