### PR TITLE
chore(release): changeset for v5 alpha 8

### DIFF
--- a/.changeset/v5-rc-plan-phase0.md
+++ b/.changeset/v5-rc-plan-phase0.md
@@ -1,0 +1,17 @@
+---
+"@open-wa/core": patch
+"@open-wa/config": patch
+"@open-wa/schema": patch
+"@open-wa/wa-automate": patch
+"@open-wa/plugin-sdk": patch
+---
+
+v5 RC plan (phase 0): hardening, v4-compat harness, Effect v4 foundation, and generated-docs overhaul.
+
+- **core**: strip crash-inducing browser args (`--single-process` / `--no-zygote`) by default with an `allowDangerousBrowserArgs` escape hatch; Effect v4 foundation — `OpenWAError` boundary (`toPublicError`/`runToPromise`, "Effect never leaks") and `httpClient` retry on Effect.
+- **config**: new `allowDangerousBrowserArgs` option; generated config-reference manifest for the docs config explorer.
+- **wa-automate**: thread `allowDangerousBrowserArgs`; document the Effect-never-leaks boundary in the public contract; reserve `skills/` in published files.
+- **plugin-sdk**: full README (was a stub); reserve `skills/` in published files.
+- **schema**: richer generated client reference — typed outputs (no more `unknown`), per-method request/response examples, registry-derived internals pages, generated events and licensed-methods pages, and interface-aware usage examples (Embedded / SocketClient / Easy API).
+
+Also (non-published): Docker image now builds on Node 22, the legacy v4 package was removed, a v4-compat parity harness and docs quality gate were added, and the docs site gained a config explorer and a site-wide preferred-interface selector.


### PR DESCRIPTION
Adds a Changesets entry for the v5 RC-plan phase-0 work merged in #3372, so the next release captures it.

## What this does
- One `patch` changeset for the fixed `@open-wa/*` group. Combined with the pending dashboard changesets, `changeset version` in the current `alpha` pre-mode produces **`5.0.0-alpha.8`** (alpha.7 is already published; this stays on the alpha train, not RC).

## Changelog summary (see the changeset for the full text)
- **core**: strip crash-inducing browser args by default (`allowDangerousBrowserArgs` escape hatch); Effect v4 foundation (`OpenWAError` boundary + `httpClient` retry on Effect).
- **config**: `allowDangerousBrowserArgs`; generated config-reference manifest.
- **wa-automate**: thread the flag; Effect-never-leaks public contract; `skills/` in files.
- **plugin-sdk**: full README; `skills/` in files.
- **schema**: richer generated client reference (typed outputs, request/response examples, internals + events + licensed-methods pages, interface-aware examples).

## Release flow
Merge to `master` → the Changesets action opens the "Version Packages" PR → merging that to `release` publishes `5.0.0-alpha.8` and (via `release: published`) triggers the docs deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upcoming release plan and included several package dependency updates.
* **Documentation**
  * Expanded release documentation to cover updated configuration guidance, reserved publish paths, and broader API/schema docs.
  * Improved the documentation site with easier config browsing and interface selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->