### PR TITLE
docs: deploy pipeline fix + config explorer readability + openwa.dev canonical origin

### DIFF
--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -1,24 +1,53 @@
-name: Build & Publish Documentation
+name: Build & Deploy Documentation
+
+# Builds the v5 docs app (apps/docs) and deploys it to Cloudflare Workers
+# (the `openwa-docs` worker, per apps/docs/wrangler.jsonc).
+#
+# Requires two repo secrets: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID.
 
 on:
   release:
     types: [published]
   workflow_dispatch:
-    
+  push:
+    branches: [master]
+    paths:
+      - 'apps/docs/**'
+      - 'packages/schema/**'
+      - 'packages/config/**'
+      - '.github/workflows/docs-run.yml'
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
         with:
-          token: ${{ secrets.CUSTOM_GH_TOKEN }}
-      - run: npm ci
-      - run: npm run build
-      - run: npm i
-      - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - run: git config --global user.name "github-actions[bot]"
-      - run: npm run docs
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
         env:
-          GIT_USER: smashah
-          GIT_PASS: ${{ secrets.CUSTOM_GH_TOKEN }}
+          PUPPETEER_SKIP_DOWNLOAD: '1'
+
+      - name: Build docs
+        run: pnpm --filter docs build
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: '1'
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/docs
+          command: deploy

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ pnpm build
 
 This repo is no longer just a single package. It includes a plugin/integration surface for extending the runtime.
 
-Want to build one? Start with the **[plugin authoring guide](https://docs.openwa.dev/docs/plugins/getting-started)** (`@open-wa/plugin-sdk`).
+Want to build one? Start with the **[plugin authoring guide](https://openwa.dev/docs/plugins/getting-started)** (`@open-wa/plugin-sdk`).
 
 Relevant packages in this repo:
 
@@ -460,13 +460,13 @@ If you are testing v5, treat it like a new runtime surface rather than a drop-in
 
 The current docs in this repo are organized around real usage modes. Start with:
 
-- **Easy API quick start**: https://docs.openwa.dev/docs/getting-started/easy-api
-- **Custom code**: https://docs.openwa.dev/docs/getting-started/custom-code
-- **Socket Client**: https://docs.openwa.dev/docs/client-and-integrations/socket-client
-- **Cloudflare Session Proxy**: https://docs.openwa.dev/docs/client-and-integrations/cf-proxy
-- **Configuration and CLI**: https://docs.openwa.dev/docs/guides/configuration-and-cli
-- **Chatwoot**: https://docs.openwa.dev/docs/client-and-integrations/chatwoot
-- **Core reference**: https://docs.openwa.dev/docs/reference/core
+- **Easy API quick start**: https://openwa.dev/docs/getting-started/easy-api
+- **Custom code**: https://openwa.dev/docs/getting-started/custom-code
+- **Socket Client**: https://openwa.dev/docs/client-and-integrations/socket-client
+- **Cloudflare Session Proxy**: https://openwa.dev/docs/client-and-integrations/cf-proxy
+- **Configuration and CLI**: https://openwa.dev/docs/guides/configuration-and-cli
+- **Chatwoot**: https://openwa.dev/docs/client-and-integrations/chatwoot
+- **Core reference**: https://openwa.dev/docs/reference/core
 
 ## Running this repo locally
 
@@ -494,7 +494,7 @@ If you need help, paid support, or consulting:
 
 | Description | Link |
 | --- | --- |
-| Documentation | https://docs.openwa.dev |
+| Documentation | https://openwa.dev |
 | Discord | https://discord.gg/dnpp72a |
 | Get a license key | https://openwa.page.link/key |
 | Donate or book 1 hour consult | [![Buy me a coffee][buymeacoffee-shield]][buymeacoffee] |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -13,7 +13,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docker/docker-compose.yaml
+++ b/apps/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      WA_DISABLE_SPINS: 'true' # Example cli config as ENV VAR. Use any flag from https://docs.openwa.dev/docs/configuration/command-line-options and convert to capital snake case with `WA_` prefix
+      WA_DISABLE_SPINS: 'true' # Example cli config as ENV VAR. Use any flag from https://openwa.dev/docs/configuration/command-line-options and convert to capital snake case with `WA_` prefix
       WA_SESSION_ID: "MY_SESSION" # Change this
 
 volumes:

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -19,7 +19,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -80,7 +80,7 @@ This project is unofficial and is not affiliated with WhatsApp or Meta. Use it a
 
 ## Support
 
-- **Documentation**: https://docs.openwa.dev
+- **Documentation**: https://openwa.dev
 - **Discord**: https://discord.gg/dnpp72a
 - **Get a license key**: https://openwa.page.link/key
 

--- a/apps/docs/content/docs/reference/workspaces/apps/cli.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/cli.mdx
@@ -20,7 +20,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/apps/dashboard-neo.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/dashboard-neo.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@open-wa/dashboard-neo"
-description: "@open-wa/dashboard-neo workspace in the open-wa v5 monorepo."
+description: "Static dashboard UI for the open-wa v5 Easy API."
 ---
 
 > Generated from `apps/dashboard-neo/README.md` by `apps/docs/scripts/gen-workspace-readme-docs.js`. Do not edit this page directly.

--- a/apps/docs/content/docs/reference/workspaces/apps/docs.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/docs.mdx
@@ -26,7 +26,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/apps/index.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/index.mdx
@@ -8,7 +8,7 @@ description: "README reference pages for apps workspaces."
 These pages are generated from direct child README files under `apps/`.
 
 - [@open-wa/cli-app](./cli) - WhatsApp CLI - Easy API mode for @open-wa/wa-automate
-- [@open-wa/dashboard-neo](./dashboard-neo) - @open-wa/dashboard-neo workspace in the open-wa v5 monorepo.
+- [@open-wa/dashboard-neo](./dashboard-neo) - Static dashboard UI for the open-wa v5 Easy API.
 - [@open-wa/docker](./docker) - This is a simple app that will expose an API that you can use to control your whatsapp instance.
 - [docs](./docs) - docs workspace in the open-wa v5 monorepo.
 - [@open-wa/orchestrator-cli](./orchestrator-cli) - Multi-session orchestration CLI

--- a/apps/docs/content/docs/reference/workspaces/apps/orchestrator-cli.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/orchestrator-cli.mdx
@@ -20,7 +20,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/apps/orchestrator-dashboard.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/orchestrator-dashboard.mdx
@@ -20,7 +20,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/apps/registry.mdx
+++ b/apps/docs/content/docs/reference/workspaces/apps/registry.mdx
@@ -18,7 +18,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/integrations/chatwoot.mdx
+++ b/apps/docs/content/docs/reference/workspaces/integrations/chatwoot.mdx
@@ -60,7 +60,7 @@ The generated webhook URL is `/plugins/chatwoot/webhook` under the selected API 
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/integrations/cloudflare.mdx
+++ b/apps/docs/content/docs/reference/workspaces/integrations/cloudflare.mdx
@@ -54,7 +54,7 @@ The session ID is sanitized with non-alphanumeric characters replaced by `_` and
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/integrations/node-red.mdx
+++ b/apps/docs/content/docs/reference/workspaces/integrations/node-red.mdx
@@ -73,7 +73,7 @@ The visible editor templates and runtime source define these fields.
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/integrations/s3.mdx
+++ b/apps/docs/content/docs/reference/workspaces/integrations/s3.mdx
@@ -62,7 +62,7 @@ The configuration type is `S3Config` in `src/config.ts`.
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/integrations/webhook.mdx
+++ b/apps/docs/content/docs/reference/workspaces/integrations/webhook.mdx
@@ -70,7 +70,7 @@ The payload shape is defined by `WebhookPayload` in `src/config.ts` and produced
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/api.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/api.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/api
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/cf-proxy.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/cf-proxy.mdx
@@ -20,7 +20,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/cli.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/cli.mdx
@@ -31,7 +31,7 @@ wa-automate --help
 
 ## Documentation
 
-See the [CLI reference](https://docs.openwa.dev/reference/cli) on our docs site.
+See the [CLI reference](https://openwa.dev/reference/cli) on our docs site.
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/client.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/client.mdx
@@ -37,7 +37,7 @@ await client.sendText('1234567890@c.us', 'Hello from v5!');
 
 ## Documentation
 
-See the [Developer Guide](https://docs.openwa.dev/guides/client) on our docs site.
+See the [Developer Guide](https://openwa.dev/guides/client) on our docs site.
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/config.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/config.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/config
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/core.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/core.mdx
@@ -27,7 +27,7 @@ pnpm add @open-wa/core
 
 ## Documentation
 
-See the [architecture overview](https://docs.openwa.dev/concepts/architecture) on our docs site.
+See the [architecture overview](https://openwa.dev/concepts/architecture) on our docs site.
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/decrypt.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/decrypt.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/decrypt
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/domain.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/domain.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/domain
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/driver-interface.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/driver-interface.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/driver-interface
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/driver-lightpanda.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/driver-lightpanda.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/driver-lightpanda
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/driver-playwright.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/driver-playwright.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/driver-playwright
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/driver-puppeteer.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/driver-puppeteer.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/driver-puppeteer
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/legacy-documented.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/legacy-documented.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/legacy-documented
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/logger.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/logger.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/logger
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/mcp.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/mcp.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/mcp
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/plugin-sdk.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/plugin-sdk.mdx
@@ -120,11 +120,11 @@ export default {
 Full authoring guide, hooks reference, security model, publishing, and worked
 examples are on the docs site:
 
-- [Getting started with plugins](https://docs.openwa.dev/docs/plugins/getting-started)
-- [Hooks reference](https://docs.openwa.dev/docs/plugins/hooks-reference)
-- [Plugin client](https://docs.openwa.dev/docs/plugins/plugin-client)
-- [Security model](https://docs.openwa.dev/docs/plugins/security-model)
-- [Publishing a plugin](https://docs.openwa.dev/docs/plugins/publishing)
+- [Getting started with plugins](https://openwa.dev/docs/plugins/getting-started)
+- [Hooks reference](https://openwa.dev/docs/plugins/hooks-reference)
+- [Plugin client](https://openwa.dev/docs/plugins/plugin-client)
+- [Security model](https://openwa.dev/docs/plugins/security-model)
+- [Publishing a plugin](https://openwa.dev/docs/plugins/publishing)
 
 Real reference plugins in this repo:
 

--- a/apps/docs/content/docs/reference/workspaces/packages/schema.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/schema.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/schema
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/screencaster.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/screencaster.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/screencaster
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/session-sync.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/session-sync.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/session-sync
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/types-only.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/types-only.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/wa-automate-types-only
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/ui-components.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/ui-components.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/ui-components
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/utils.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/utils.mdx
@@ -19,7 +19,7 @@ pnpm add @open-wa/utils
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/content/docs/reference/workspaces/packages/wa-automate.mdx
+++ b/apps/docs/content/docs/reference/workspaces/packages/wa-automate.mdx
@@ -32,7 +32,7 @@ wa-automate --help
 
 ## Documentation
 
-For full guides and API reference, visit the [docs site](https://docs.openwa.dev).
+For full guides and API reference, visit the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/docs/scripts/gen-workspace-readme-docs.js
+++ b/apps/docs/scripts/gen-workspace-readme-docs.js
@@ -53,7 +53,7 @@ function buildMissingReadme(workspace) {
     '',
     '## Documentation',
     '',
-    'See the [docs site](https://docs.openwa.dev).',
+    'See the [docs site](https://openwa.dev).',
     '',
     '## License',
     '',

--- a/apps/docs/scripts/test-og.ts
+++ b/apps/docs/scripts/test-og.ts
@@ -27,17 +27,17 @@ assert.equal(
 
 assert.equal(
   getAbsoluteDocsUrl('/og/docs/getting-started/quickstart/image.webp'),
-  'https://docs.openwa.dev/og/docs/getting-started/quickstart/image.webp',
+  'https://openwa.dev/og/docs/getting-started/quickstart/image.webp',
 );
 
 const meta = getDocsSocialMeta({
   title: 'Quickstart',
   description: 'Start here',
-  imageUrl: 'https://docs.openwa.dev/og/docs/getting-started/quickstart/image.webp',
+  imageUrl: 'https://openwa.dev/og/docs/getting-started/quickstart/image.webp',
 });
 assert.deepEqual(meta.find((item) => 'property' in item && item.property === 'og:image'), {
   property: 'og:image',
-  content: 'https://docs.openwa.dev/og/docs/getting-started/quickstart/image.webp',
+  content: 'https://openwa.dev/og/docs/getting-started/quickstart/image.webp',
 });
 assert.deepEqual(meta.find((item) => 'name' in item && item.name === 'twitter:card'), {
   name: 'twitter:card',

--- a/apps/docs/src/components/config-explorer.tsx
+++ b/apps/docs/src/components/config-explorer.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useMemo, useState } from 'react';
 import {
   configManifest,
@@ -143,66 +142,52 @@ export function ConfigExplorer() {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-lg border border-fd-border">
-        <table className="w-full text-sm">
-          <thead className="bg-fd-muted/50">
-            <tr>
-              <th className="text-left px-3 py-2 font-medium">
-                {FORMATS.find((f) => f.id === format)?.label}
-              </th>
-              <th className="text-left px-3 py-2 font-medium">Type</th>
-              <th className="text-left px-3 py-2 font-medium">Default</th>
-              <th className="text-left px-3 py-2 font-medium">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {grouped.map(({ group: g, entries }) => (
-              <React.Fragment key={g}>
-                <tr className="border-t border-fd-border bg-fd-muted/30">
-                  <th
-                    colSpan={4}
-                    className="px-3 py-1.5 text-left text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground"
-                  >
-                    {g}{' '}
-                    <span className="font-normal normal-case">
-                      ({entries.length})
-                    </span>
-                  </th>
-                </tr>
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-fd-border px-3 py-6 text-center text-sm text-fd-muted-foreground">
+          {emptyMessage}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {grouped.map(({ group: g, entries }) => (
+            <section key={g} className="flex flex-col gap-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+                {g}{' '}
+                <span className="font-normal normal-case">
+                  ({entries.length})
+                </span>
+              </h3>
+              <div className="divide-y divide-fd-border/60 rounded-lg border border-fd-border">
                 {entries.map((entry) => (
-                  <tr
-                    key={entry.key}
-                    className="border-t border-fd-border/60 align-top"
-                  >
-                    <td className="px-3 py-2 font-mono text-xs whitespace-nowrap">
-                      {representation(entry, format)}
-                    </td>
-                    <td className="px-3 py-2 font-mono text-xs text-fd-muted-foreground whitespace-nowrap">
-                      {entry.type}
-                    </td>
-                    <td className="px-3 py-2 font-mono text-xs text-fd-muted-foreground whitespace-nowrap">
-                      {entry.default ?? '—'}
-                    </td>
-                    <td className="px-3 py-2 text-fd-muted-foreground">
-                      {entry.description ?? ''}
-                    </td>
-                  </tr>
+                  <div key={entry.key} className="flex flex-col gap-1.5 p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <code className="rounded bg-fd-muted px-1.5 py-0.5 font-mono text-xs break-all">
+                        {representation(entry, format)}
+                      </code>
+                      <span className="rounded border border-fd-border px-1.5 py-0.5 font-mono text-[11px] text-fd-muted-foreground">
+                        {entry.type}
+                      </span>
+                      {entry.default && entry.default !== 'null' ? (
+                        <span className="rounded border border-fd-border px-1.5 py-0.5 font-mono text-[11px] text-fd-muted-foreground">
+                          default: {entry.default}
+                        </span>
+                      ) : (
+                        <span className="rounded border border-fd-border px-1.5 py-0.5 text-[11px] text-fd-muted-foreground">
+                          optional
+                        </span>
+                      )}
+                    </div>
+                    {entry.description && (
+                      <p className="text-sm text-fd-muted-foreground">
+                        {entry.description}
+                      </p>
+                    )}
+                  </div>
                 ))}
-              </React.Fragment>
-            ))}
-            {filtered.length === 0 && (
-              <tr>
-                <td
-                  colSpan={4}
-                  className="px-3 py-6 text-center text-fd-muted-foreground"
-                >
-                  {emptyMessage}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
 
       <details className="rounded-lg border border-fd-border">
         <summary className="cursor-pointer px-3 py-2 text-sm font-medium">

--- a/apps/docs/src/lib/site.ts
+++ b/apps/docs/src/lib/site.ts
@@ -2,8 +2,9 @@ export type LicenseTier = 'insiders' | 'restricted';
 
 export const SITE_NAME = 'open-wa v5 docs';
 // Canonical origin for the docs site. Used for sitemap, robots, OG image URLs,
-// and og:url so they never disagree. If the docs deploy moves, change it here.
-export const SITE_ORIGIN = 'https://docs.openwa.dev';
+// and og:url so they never disagree. The docs are served at openwa.dev (there
+// is no docs.openwa.dev subdomain). If the deploy moves, change it here.
+export const SITE_ORIGIN = 'https://openwa.dev';
 export const REPO_URL = 'https://github.com/open-wa/wa-automate-nodejs';
 export const GENERIC_LICENSE_URL = 'https://smashah.gumroad.com/l/open-wa?wanted=true';
 export const GENERIC_GUMROAD_URL = 'https://smashah.gumroad.com/l/open-wa?wanted=true';

--- a/apps/docs/src/routes/[.]well-known.mcp.server-card[.]json.ts
+++ b/apps/docs/src/routes/[.]well-known.mcp.server-card[.]json.ts
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/.well-known/mcp/server-card.json')({
           JSON.stringify(
             {
               error: 'MCP is not hosted on the docs site.',
-              docs: 'https://docs.openwa.dev/docs/guides/mcp',
+              docs: 'https://openwa.dev/docs/guides/mcp',
               runtimeEndpoint: '/mcp',
             },
             null,

--- a/apps/orchestrator-cli/README.md
+++ b/apps/orchestrator-cli/README.md
@@ -13,7 +13,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/orchestrator-dashboard/README.md
+++ b/apps/orchestrator-dashboard/README.md
@@ -13,7 +13,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -11,7 +11,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/integrations/chatwoot/README.md
+++ b/integrations/chatwoot/README.md
@@ -53,7 +53,7 @@ The generated webhook URL is `/plugins/chatwoot/webhook` under the selected API 
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/integrations/cloudflare/README.md
+++ b/integrations/cloudflare/README.md
@@ -47,7 +47,7 @@ The session ID is sanitized with non-alphanumeric characters replaced by `_` and
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/integrations/node-red/README.md
+++ b/integrations/node-red/README.md
@@ -66,7 +66,7 @@ The visible editor templates and runtime source define these fields.
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/integrations/s3/README.md
+++ b/integrations/s3/README.md
@@ -55,7 +55,7 @@ The configuration type is `S3Config` in `src/config.ts`.
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/integrations/webhook/README.md
+++ b/integrations/webhook/README.md
@@ -63,7 +63,7 @@ The payload shape is defined by `WebhookPayload` in `src/config.ts` and produced
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/api
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/cf-proxy/README.md
+++ b/packages/cf-proxy/README.md
@@ -13,7 +13,7 @@ Part of the [@open-wa v5 monorepo](https://github.com/open-wa/wa-automate-nodejs
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ wa-automate --help
 
 ## Documentation
 
-See the [CLI reference](https://docs.openwa.dev/reference/cli) on our docs site.
+See the [CLI reference](https://openwa.dev/reference/cli) on our docs site.
 
 ## License
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -30,7 +30,7 @@ await client.sendText('1234567890@c.us', 'Hello from v5!');
 
 ## Documentation
 
-See the [Developer Guide](https://docs.openwa.dev/guides/client) on our docs site.
+See the [Developer Guide](https://openwa.dev/guides/client) on our docs site.
 
 ## License
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/config
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ pnpm add @open-wa/core
 
 ## Documentation
 
-See the [architecture overview](https://docs.openwa.dev/concepts/architecture) on our docs site.
+See the [architecture overview](https://openwa.dev/concepts/architecture) on our docs site.
 
 ## License
 

--- a/packages/decrypt/README.md
+++ b/packages/decrypt/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/decrypt
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/decrypt/src/download.ts
+++ b/packages/decrypt/src/download.ts
@@ -41,7 +41,7 @@ export async function downloadEncryptedMedia(
     if (res.status === 404) {
       throw new Error(
         'This media does not exist or is no longer available on the server. ' +
-          'See: https://docs.openwa.dev/pages/How%20to/decrypt-media.html#40439d',
+          'See: https://openwa.dev/pages/How%20to/decrypt-media.html#40439d',
       );
     }
 

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/domain
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/driver-interface/README.md
+++ b/packages/driver-interface/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/driver-interface
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/driver-lightpanda/README.md
+++ b/packages/driver-lightpanda/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/driver-lightpanda
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/driver-playwright/README.md
+++ b/packages/driver-playwright/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/driver-playwright
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/driver-puppeteer/README.md
+++ b/packages/driver-puppeteer/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/driver-puppeteer
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/logger
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/mcp
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -113,11 +113,11 @@ export default {
 Full authoring guide, hooks reference, security model, publishing, and worked
 examples are on the docs site:
 
-- [Getting started with plugins](https://docs.openwa.dev/docs/plugins/getting-started)
-- [Hooks reference](https://docs.openwa.dev/docs/plugins/hooks-reference)
-- [Plugin client](https://docs.openwa.dev/docs/plugins/plugin-client)
-- [Security model](https://docs.openwa.dev/docs/plugins/security-model)
-- [Publishing a plugin](https://docs.openwa.dev/docs/plugins/publishing)
+- [Getting started with plugins](https://openwa.dev/docs/plugins/getting-started)
+- [Hooks reference](https://openwa.dev/docs/plugins/hooks-reference)
+- [Plugin client](https://openwa.dev/docs/plugins/plugin-client)
+- [Security model](https://openwa.dev/docs/plugins/security-model)
+- [Publishing a plugin](https://openwa.dev/docs/plugins/publishing)
 
 Real reference plugins in this repo:
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/schema
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/screencaster/README.md
+++ b/packages/screencaster/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/screencaster
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/session-sync/README.md
+++ b/packages/session-sync/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/session-sync
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/types-only/README.md
+++ b/packages/types-only/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/wa-automate-types-only
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/ui-components
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -12,7 +12,7 @@ pnpm add @open-wa/utils
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 

--- a/packages/wa-automate/README.md
+++ b/packages/wa-automate/README.md
@@ -25,7 +25,7 @@ wa-automate --help
 
 ## Documentation
 
-For full guides and API reference, visit the [docs site](https://docs.openwa.dev).
+For full guides and API reference, visit the [docs site](https://openwa.dev).
 
 ## License
 

--- a/tools/release/V5_RELEASE_CHECKLIST.md
+++ b/tools/release/V5_RELEASE_CHECKLIST.md
@@ -141,7 +141,7 @@ pnpm add @open-wa/<name>
 
 ## Documentation
 
-See the [docs site](https://docs.openwa.dev).
+See the [docs site](https://openwa.dev).
 
 ## License
 
@@ -152,7 +152,7 @@ See the [docs site](https://docs.openwa.dev).
 
 ## 3. 📖 Documentation Coverage (apps/docs)
 
-Every public package should have at least a docs page at `docs.openwa.dev`. Check the docs site for coverage:
+Every public package should have at least a docs page at `openwa.dev`. Check the docs site for coverage:
 
 ### How to verify
 
@@ -175,7 +175,7 @@ curl -s http://localhost:3000/sitemap.xml | grep -i "package\|api\|guide"
 - [ ] **Migration from v4** guide exists (if applicable)
 - [ ] **Package overview page** lists all public packages with one-line descriptions
 - [ ] **API Reference** links to generated typedocs (if available)
-- [ ] Every package's README links back to `docs.openwa.dev`
+- [ ] Every package's README links back to `openwa.dev`
 
 > [!TIP]
 > The docs site at `apps/docs` uses file-based routing. Add new pages in `apps/docs/src/routes/docs/`.


### PR DESCRIPTION
Three docs fixes (all live-deployed to openwa.dev from local while these await merge).

## 1. Docs deploy pipeline
`docs-run.yml` was v4-era (npm + a non-existent `docs` script) so the docs never deployed. Rewrote it to pnpm build `apps/docs` + `cloudflare/wrangler-action` deploy to the `openwa-docs` Worker. Triggers: release, manual dispatch, and docs-touching pushes. Needs `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets.

## 2. Config explorer defaults + descriptions
The wide overflow table pushed the Default/Description columns off-screen. Replaced with a responsive per-option list — each option shows its name (in the selected format), a type badge, a `default: …` or `optional` badge, and the description full-width below. All 115 options now show their default and description.

## 3. Canonical origin → openwa.dev
There is no `docs.openwa.dev` subdomain; the site is served at `openwa.dev`. Pointed `SITE_ORIGIN` (sitemap, robots, OG image URLs, `og:url`) at openwa.dev and swept every `docs.openwa.dev` reference across content, READMEs, generated workspace docs, the MCP server-card route, docker-compose, and the OG test. (CNAME left as-is — it's a stale GitHub Pages artifact; delete it if Pages is unused.)

Verified live on openwa.dev: config explorer shows defaults/descriptions, sitemap/robots/og:image all use openwa.dev, and the OG image resolves 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the docs site pipeline to automatically build and deploy to Cloudflare on release publishes, manual runs, and relevant docs-related changes.
  * Refreshed the Config Explorer results view to use card/section layouts with a clearer empty state.
* **Documentation**
  * Updated documentation links across READMEs and reference pages to the new `https://openwa.dev` domain.
* **Bug Fixes**
  * Corrected docs URLs in well-known MCP server-card responses and in social preview metadata to match the new domain.
* **Chores**
  * Added deploy concurrency to prevent overlapping documentation deploys and streamlined the docs build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->