### PR TITLE
ci(release): harden release install (skip Puppeteer download)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      # The release only builds and publishes packages — it never needs a
+      # browser. Skip the Puppeteer Chromium download during install/build.
+      PUPPETEER_SKIP_DOWNLOAD: '1'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The last release runs (June 7) failed at `pnpm build` inside `publish-packages.sh` on the pre-migration codebase — not npm auth. The current master builds cleanly (35/35), and the workflow now uses pnpm 11 (via packageManager).

This adds `PUPPETEER_SKIP_DOWNLOAD=1` at the release job level so `pnpm install` doesn't download Chromium (the release only builds/publishes packages — no browser needed), removing a slow, flake-prone step.

Merge this before cutting the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to skip an unnecessary browser download, helping keep releases faster and lighter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->