### PR TITLE
👷 chore(release): don't let a failed release image block the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,22 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       # ── Post-publish: Generate release image ─────────────────────
+      # The image is rendered with Puppeteer/Chrome, but the job skips the
+      # Chromium download (PUPPETEER_SKIP_DOWNLOAD) to keep install/build lean,
+      # so fetch a browser here just for this cosmetic step. Both this install
+      # and the render are continue-on-error: a missing release image must
+      # never block the actual GitHub Release / Discord notification (the
+      # Create GitHub Release step already handles an absent release.png).
+      - name: Install Chrome for release image
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: '0'
+        run: npx puppeteer browsers install chrome
+
       - name: Generate release image
         if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
         run: node tools/release-image.js --version ${{ steps.version.outputs.version }}
 
       # ── Post-publish: Create GitHub Release ──────────────────────


### PR DESCRIPTION
## Problem

The alpha.8 release published to npm successfully, but the **GitHub Release** and **Discord notification** steps were skipped.

Root cause: the release job sets `PUPPETEER_SKIP_DOWNLOAD='1'` (to keep install/build lean — this is what unblocked the build after #3378). But `tools/release-image.js` renders the release image with Puppeteer/Chrome, so with no browser available it threw `Could not find Chrome`. Because that step exited non-zero, every following step gated on the implicit `success()` (`Create GitHub Release`, `Notify Discord`) was skipped — even though `published == 'true'`.

## Fix

- Install Chrome just-in-time for the cosmetic image step (overriding the skip for that one step).
- Mark both the install and the render `continue-on-error: true` so a missing release image can **never** block the actual release. The `Create GitHub Release` step already handles an absent `release.png`.

npm publish is unaffected — this only hardens the post-publish notification steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release image generation process by ensuring Chrome is installed before the image is created.
  * Added a fallback-friendly setup so release publishing is less likely to fail when browser components are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->