### PR TITLE
👷 fix(docs): generate schema OpenAPI before docs build (fixes CF deploy)

### DIFF
--- a/.github/workflows/docs-run.yml
+++ b/.github/workflows/docs-run.yml
@@ -39,6 +39,16 @@ jobs:
         env:
           PUPPETEER_SKIP_DOWNLOAD: '1'
 
+      # The docs app copies packages/schema/src/generated/openapi.json into
+      # public/ during prebuild, but that file (and the rest of schema's
+      # generated/ dir) is gitignored, so a fresh checkout doesn't have it.
+      # Build schema and its workspace deps first — schema's build runs its
+      # code generation, which (re)produces openapi.json before the docs build.
+      - name: Build schema (generates OpenAPI spec)
+        run: pnpm --filter @open-wa/schema... build
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: '1'
+
       - name: Build docs
         run: pnpm --filter docs build
         env:


### PR DESCRIPTION
## Problem

The docs deploy (triggered by the `v5.0.0-alpha.8` release) failed:

```
Error: ENOENT: no such file or directory, copyfile
  '.../packages/schema/src/generated/openapi.json' -> '.../apps/docs/public/openapi.json'
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] docs@ prebuild: `pnpm openapi`
```

The docs `prebuild` runs `copy-openapi.js`, which copies `packages/schema/src/generated/openapi.json` into `public/`. But schema's `generated/` dir is gitignored (`packages/schema/.gitignore`), so it doesn't exist in a fresh CI checkout — and the workflow never ran schema's codegen. It only passed locally because the file was already on disk. (Same class of bug as #3378.)

## Fix

Add a step that builds `@open-wa/schema` and its workspace deps before the docs build:

```yaml
- name: Build schema (generates OpenAPI spec)
  run: pnpm --filter @open-wa/schema... build
```

schema's `build` runs `pnpm generate` (gen-openapi + gen-types + client impl + client reference docs), which (re)produces `openapi.json` before docs prebuild copies it.

## Verification

Locally, after deleting `openapi.json`:
- `pnpm --filter @open-wa/schema... build` → regenerates `openapi.json` (224 KB) ✅
- `pnpm --filter docs build` → full prerender succeeds, `dist/client` + `dist/server` + `public/openapi.json` produced ✅

The committed client-reference MDX and `config-manifest.ts` are unaffected (already tracked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the documentation build pipeline so docs generate reliably in fresh environments.
  * Fixed missing generated documentation assets during CI builds, reducing build failures and incomplete docs output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->