### PR TITLE
fix(api): require API key for management routes

### DIFF
--- a/.changeset/protect-api-management-routes.md
+++ b/.changeset/protect-api-management-routes.md
@@ -1,0 +1,5 @@
+---
+'@open-wa/api': patch
+---
+
+Require the configured Easy API key for screencast, QR, debug, and integration-management routes, and keep QR data out of the public health response.

--- a/packages/api/src/createApiServer.ts
+++ b/packages/api/src/createApiServer.ts
@@ -15,6 +15,7 @@ import { createHonoMcpAdapter } from '@open-wa/mcp';
 import { registerMetaRoutes } from './routes/meta';
 import { registerDebugRoutes } from './routes/debug';
 import { registerAgentDiscoveryRoutes } from './routes/agent-discovery';
+import { apiKeyMiddleware } from './auth/api-key';
 import { type EventBridge } from './events/EventBridge';
 import { HealthStore } from './health/HealthStore';
 import { EventBroadcaster } from './events/EventBroadcaster';
@@ -100,6 +101,7 @@ export class ApiServer {
     }
 
     this.setupMiddleware();
+    this.setupManagementAuthentication();
     this.registerRoutes();
 
     // Register screencast WebSocket route
@@ -300,6 +302,19 @@ export class ApiServer {
     }
   }
 
+  private setupManagementAuthentication() {
+    if (!this.config.apiKey) {
+      return;
+    }
+
+    const authenticate = apiKeyMiddleware(this.config.apiKey);
+    this.app.use('/meta/debug/*', authenticate);
+    this.app.use('/meta/integrations', authenticate);
+    this.app.use('/meta/integrations/*', authenticate);
+    this.app.use('/qr', authenticate);
+    this.app.use('/screencast', authenticate);
+  }
+
   private registerRoutes() {
     const methodDefinitions = getHttpMethodDefinitions();
     registerAgentDiscoveryRoutes(this.app, {
@@ -348,7 +363,8 @@ export class ApiServer {
           exposureSafe: false,
         },
         // QR code for pre-launch scanning
-        qr: this.latestQR ?? null,
+        // Keep the health probe public without bypassing the authenticated QR route.
+        qr: this.config.apiKey ? null : (this.latestQR ?? null),
         // Accumulated health data for the dashboard
         launchTimeline: healthSnapshot.launchTimeline,
         patches: healthSnapshot.patches,

--- a/packages/api/test/management-auth.test.ts
+++ b/packages/api/test/management-auth.test.ts
@@ -86,10 +86,16 @@ describe('management route authentication', () => {
   });
 
   it('preserves management routes when authentication is not configured', async () => {
-    const app = createApiServer(createConfig()).getApp();
+    const server = createApiServer(createConfig());
+    server.setQR('public-qr-data');
+    const app = server.getApp();
 
-    const response = await app.request('/meta/integrations');
+    const integrations = await app.request('/meta/integrations');
+    const health = await app.request('/health');
+    const healthBody = (await health.json()) as { qr: string | null };
 
-    expect(response.status).toBe(200);
+    expect(integrations.status).toBe(200);
+    expect(health.status).toBe(200);
+    expect(healthBody.qr).toBe('public-qr-data');
   });
 });

--- a/packages/api/test/management-auth.test.ts
+++ b/packages/api/test/management-auth.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { Config } from '@open-wa/config';
+import { createApiServer } from '../src/createApiServer.js';
+
+function createConfig(apiKey?: string): Config {
+  return {
+    sessionName: 'management-auth-test',
+    apiKey,
+    cors: '*',
+    ezqr: true,
+    integrations: {
+      chatwoot: {
+        enabled: true,
+        config: { apiAccessToken: 'integration-secret' },
+      },
+    },
+  };
+}
+
+describe('management route authentication', () => {
+  it.each([
+    '/meta/debug/memory',
+    '/meta/debug/config',
+    '/meta/debug/info',
+    '/meta/integrations',
+    '/qr',
+    '/screencast',
+  ])(
+    'rejects unauthenticated requests to %s when an API key is configured',
+    async (path) => {
+      const app = createApiServer(createConfig('configured-secret')).getApp();
+
+      const response = await app.request(path);
+
+      expect(response.status).toBe(401);
+    },
+  );
+
+  it('does not mutate integration configuration without the API key', async () => {
+    const config = createConfig('configured-secret');
+    const app = createApiServer(config).getApp();
+
+    const response = await app.request('/meta/integrations/chatwoot', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(config.integrations?.chatwoot?.enabled).toBe(true);
+  });
+
+  it('allows authenticated management requests', async () => {
+    const server = createApiServer(createConfig('configured-secret'));
+    server.setQR('private-qr-data');
+    const app = server.getApp();
+
+    const integrations = await app.request('/meta/integrations', {
+      headers: { 'X-API-Key': 'configured-secret' },
+    });
+    const qr = await app.request('/qr?api_key=configured-secret');
+
+    expect(integrations.status).toBe(200);
+    expect(await integrations.json()).toEqual({
+      chatwoot: {
+        enabled: true,
+        config: { apiAccessToken: 'integration-secret' },
+      },
+    });
+    expect(qr.status).toBe(200);
+    expect(await qr.json()).toEqual({
+      qr: 'private-qr-data',
+      note: 'Scan this QR code in WhatsApp',
+    });
+  });
+
+  it('does not expose QR data through the public health endpoint', async () => {
+    const server = createApiServer(createConfig('configured-secret'));
+    server.setQR('private-qr-data');
+
+    const response = await server.getApp().request('/health');
+    const health = (await response.json()) as { qr: string | null };
+
+    expect(response.status).toBe(200);
+    expect(health.qr).toBeNull();
+  });
+
+  it('preserves management routes when authentication is not configured', async () => {
+    const app = createApiServer(createConfig()).getApp();
+
+    const response = await app.request('/meta/integrations');
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

- apply the configured Easy API key middleware to screencast, QR, debug, and integration-management routes
- prevent the public health response from returning QR pairing data when API-key authentication is enabled
- preserve the existing unauthenticated behavior when no API key is configured
- add focused regression coverage and a patch changeset

## Security impact

The v5 API server mounts these routes outside the authenticated /api subrouter. As a result, configuring an API key does not currently protect management endpoints that expose runtime configuration, mutate integrations, disclose pairing data, or reach the browser screencast/control channel.

This change makes the configured API key a consistent boundary for those management surfaces. Header authentication remains available through X-API-Key; the existing query-key compatibility remains available for browser WebSocket handshakes.

## Verification

- focused regression test failed against the base behavior and passes after the fix: 10/10
- @open-wa/api tests: 15/15
- monorepo build: 30/30 tasks
- @open-wa/api lint: 0 warnings, 0 errors
- Prettier and git diff checks: pass

The repository-wide baseline gates also expose unrelated existing failures:

- typecheck: @open-wa/utils does not load Node globals/types
- test: two @open-wa/schema generated-document contract expectations differ from current generator output
- lint: eight invalid Unicode escape diagnostics in packages/core/src/transport/assets/prog_observer.js

No generated output from those baseline failures is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added API-key protection for QR, screencast, debug, and integration-management endpoints when an API key is configured.
  * Updated the public health response to avoid exposing QR data when authentication is enabled.
* **Bug Fixes**
  * Ensured unauthenticated management requests are rejected and cannot change integration settings.
* **Tests**
  * Added coverage for API-key–protected route behavior, including health-response expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->