### PR TITLE
🔒 fix(api): harden privacy and endpoint authentication

### DIFF
--- a/apps/dashboard-neo/package.json
+++ b/apps/dashboard-neo/package.json
@@ -37,6 +37,7 @@
     "clsx": "catalog:",
     "lucide-react": "catalog:",
     "next-themes": "^0.4.6",
+    "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shadcn": "^4.1.2",

--- a/apps/dashboard-neo/src/components/app-sidebar.tsx
+++ b/apps/dashboard-neo/src/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ import { Link, useMatches } from "@tanstack/react-router"
 import { SessionStatusBadge } from "@/components/session-status-badge"
 import { useEffect, useState } from "react"
 import { useHealth } from "@/lib/hooks/use-health"
+import { apiFetch } from "@/lib/api-client"
 
 interface PluginPage {
   path: string
@@ -85,7 +86,7 @@ function usePluginManifest() {
     const fetchManifest = async () => {
       try {
         const base = (window as unknown as { __OPENWA_API_BASE__?: string }).__OPENWA_API_BASE__ ?? ""
-        const res = await fetch(`${base}/plugins/manifest`)
+        const res = await apiFetch(`${base}/plugins/manifest`)
         if (res.ok) {
           const data = await res.json()
           setPlugins(data.plugins ?? [])

--- a/apps/dashboard-neo/src/components/connection-badge.tsx
+++ b/apps/dashboard-neo/src/components/connection-badge.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react"
 import { useSocket } from "@/lib/hooks/use-socket"
-import { getApiUrl, resetClient } from "@/lib/api-client"
+import { getApiKey, getApiUrl, resetClient, setApiKey } from "@/lib/api-client"
 
 const STORAGE_KEY = "wa-dashboard-connection"
 
@@ -45,6 +45,7 @@ export function ConnectionBadge() {
 
   const [host, setHost] = useState(stored?.host ?? "")
   const [port, setPort] = useState(stored?.port ?? "")
+  const [apiKey, setApiKeyInput] = useState(getApiKey())
 
   // Close on outside click
   useEffect(() => {
@@ -64,6 +65,7 @@ export function ConnectionBadge() {
       const s = getStoredConnection()
       setHost(s?.host ?? "")
       setPort(s?.port ?? "")
+      setApiKeyInput(getApiKey())
     }
   }, [open])
 
@@ -73,6 +75,7 @@ export function ConnectionBadge() {
     } else {
       clearConnection()
     }
+    setApiKey(apiKey.trim())
     // Reset the cached client so next getClient() uses the new URL
     resetClient()
     setOpen(false)
@@ -82,8 +85,10 @@ export function ConnectionBadge() {
 
   const reset = () => {
     clearConnection()
+    setApiKey("")
     setHost("")
     setPort("")
+    setApiKeyInput("")
     resetClient()
     setOpen(false)
     window.location.reload()
@@ -133,6 +138,18 @@ export function ConnectionBadge() {
                 value={host}
                 onChange={(e) => setHost(e.target.value)}
                 placeholder={typeof window !== "undefined" ? window.location.hostname : "localhost"}
+                className="h-8 w-full rounded-md border bg-background px-3 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-[11px] font-medium text-muted-foreground">
+                API key (kept only for this browser tab)
+              </label>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKeyInput(e.target.value)}
+                autoComplete="off"
                 className="h-8 w-full rounded-md border bg-background px-3 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               />
             </div>

--- a/apps/dashboard-neo/src/lib/api-client.ts
+++ b/apps/dashboard-neo/src/lib/api-client.ts
@@ -18,6 +18,7 @@ export type { Client, ClientMethods } from "@open-wa/socket-client"
 import { SocketClient } from "@open-wa/socket-client"
 
 const STORAGE_KEY = "wa-dashboard-connection"
+const API_KEY_STORAGE_KEY = "wa-dashboard-api-key"
 
 // We lazy-connect so SSR doesn't try to open a socket.
 let _client: (SocketClient & import("@open-wa/socket-client").Client) | null = null
@@ -32,7 +33,7 @@ export async function getClient(url?: string) {
 
   if (!_connecting) {
     const target = url || getApiUrl()
-    _connecting = SocketClient.connect(target).then((c) => {
+    _connecting = SocketClient.connect(target, getApiKey()).then((c) => {
       _client = c
       _connecting = null
       return c
@@ -43,6 +44,27 @@ export async function getClient(url?: string) {
   }
 
   return _connecting
+}
+
+export function getApiKey(): string {
+  if (typeof window === "undefined") return ""
+  return sessionStorage.getItem(API_KEY_STORAGE_KEY) || ""
+}
+
+export function setApiKey(apiKey: string): void {
+  if (typeof window === "undefined") return
+  if (apiKey) {
+    sessionStorage.setItem(API_KEY_STORAGE_KEY, apiKey)
+  } else {
+    sessionStorage.removeItem(API_KEY_STORAGE_KEY)
+  }
+}
+
+export function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  const apiKey = getApiKey()
+  if (apiKey) headers.set("X-API-Key", apiKey)
+  return fetch(input, { ...init, headers })
 }
 
 /**

--- a/apps/dashboard-neo/src/lib/hooks/use-health.ts
+++ b/apps/dashboard-neo/src/lib/hooks/use-health.ts
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react"
-import { getApiUrl, getClient } from "@/lib/api-client"
+import { apiFetch, getApiUrl, getClient } from "@/lib/api-client"
 import { useDemo } from "@/lib/demo/use-demo"
 import {
   demoLaunchTimeline,
@@ -310,11 +310,17 @@ export function useHealth() {
   const fetchHealth = useCallback(async () => {
     try {
       const baseUrl = getApiUrl()
-      const res = await fetch(`${baseUrl}/health`, {
+      const res = await apiFetch(`${baseUrl}/health`, {
         signal: AbortSignal.timeout(5000),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = (await res.json()) as HealthData
+      const qrResponse = await apiFetch(`${baseUrl}/qr`, {
+        signal: AbortSignal.timeout(5000),
+      })
+      data.qr = qrResponse.ok
+        ? ((await qrResponse.json()) as { qr?: string }).qr ?? null
+        : null
       _cachedHealth = data
       _lastFetch = Date.now()
       if (mountedRef.current) {

--- a/apps/dashboard-neo/src/main.tsx
+++ b/apps/dashboard-neo/src/main.tsx
@@ -7,25 +7,6 @@ import "./styles.css"
 
 const router = getRouter()
 
-// Initialize WebMCP natively
-if (typeof navigator !== 'undefined' && 'modelContext' in navigator) {
-  (navigator as any).modelContext?.provideContext({
-    tools: [{
-      name: "get_open_wa_health",
-      description: "Retrieves the session state status",
-      inputSchema: { type: "object", properties: {} },
-      execute: async () => {
-        try {
-          const res = await fetch('/health');
-          return await res.json();
-        } catch (e: any) {
-          return { error: e.message || 'Failed to fetch health' };
-        }
-      }
-    }]
-  });
-}
-
 ReactDOM.createRoot(document.getElementById("app")!).render(
   <React.StrictMode>
     <RouterProvider router={router} />

--- a/apps/dashboard-neo/src/routes/debug.tsx
+++ b/apps/dashboard-neo/src/routes/debug.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { useState, useEffect } from "react"
 import { BarChart, Settings, FileText } from "lucide-react"
 import { useSocket } from "@/lib/hooks/use-socket"
-import { getClient, getApiUrl } from "@/lib/api-client"
+import { apiFetch, getClient, getApiUrl } from "@/lib/api-client"
 
 export const Route = createFileRoute("/debug")({ component: DebugPage })
 
@@ -54,8 +54,8 @@ function DebugPage() {
         const apiUrl = getApiUrl()
 
         const [memRes, configRes] = await Promise.allSettled([
-          fetch(`${apiUrl}/meta/debug/memory`).then((r) => r.json()),
-          fetch(`${apiUrl}/meta/debug/config`).then((r) => r.json()),
+          apiFetch(`${apiUrl}/meta/debug/memory`).then((r) => r.json()),
+          apiFetch(`${apiUrl}/meta/debug/config`).then((r) => r.json()),
         ])
 
         setDebug((prev) => ({

--- a/apps/dashboard-neo/src/routes/index.tsx
+++ b/apps/dashboard-neo/src/routes/index.tsx
@@ -32,6 +32,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { useMemo, useState, useEffect, useRef } from "react"
+import { toDataURL } from "qrcode"
 
 export const Route = createFileRoute("/")({ component: SessionPage })
 
@@ -83,6 +84,33 @@ function getLaunchPhase(
   return "launching"
 }
 
+function LocalQrCode({ value }: { value: string }) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setDataUrl(null)
+    toDataURL(value, { width: 256, margin: 1, errorCorrectionLevel: "M" })
+      .then((nextDataUrl) => {
+        if (active) setDataUrl(nextDataUrl)
+      })
+      .catch(() => {
+        if (active) setDataUrl(null)
+      })
+    return () => {
+      active = false
+    }
+  }, [value])
+
+  return dataUrl ? (
+    <img src={dataUrl} alt="QR Code" className="size-56" />
+  ) : (
+    <div className="flex size-56 items-center justify-center">
+      <Loader2 className="animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
 // ─── Pre-Launch View ─────────────────────────────────────────────
 function PreLaunchView({
   phase,
@@ -99,11 +127,6 @@ function PreLaunchView({
   )
   const demoTimeoutIds = useRef<ReturnType<typeof setTimeout>[]>([])
 
-  console.log({
-    phase,
-    qr,
-    isDemo,
-  })
   if (qr) phase = "qr"
   // In demo mode, drip-feed log lines to simulate a real launch
   useEffect(() => {
@@ -349,11 +372,7 @@ function PreLaunchView({
                     <div className="animate-scan absolute inset-x-3 h-0.5 bg-primary/60" />
                   </div>
                 ) : (
-                  <img
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=${encodeURIComponent(qr!)}`}
-                    alt="QR Code"
-                    className="size-56"
-                  />
+                  <LocalQrCode value={qr!} />
                 )}
               </div>
             </div>

--- a/apps/dashboard-neo/src/routes/integrations.tsx
+++ b/apps/dashboard-neo/src/routes/integrations.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { useState, useEffect, type ReactNode } from "react"
 import { MessageSquare, Link as LinkIcon, Zap, RefreshCw, Database } from "lucide-react"
 import { useSocket } from "@/lib/hooks/use-socket"
-import { getApiUrl } from "@/lib/api-client"
+import { apiFetch, getApiUrl } from "@/lib/api-client"
 
 export const Route = createFileRoute("/integrations")({ component: IntegrationsPage })
 
@@ -87,7 +87,7 @@ function IntegrationsPage() {
   useEffect(() => {
     if (!connected) return
     const apiUrl = getApiUrl()
-    fetch(`${apiUrl}/meta/integrations`)
+    apiFetch(`${apiUrl}/meta/integrations`)
       .then((r) => r.json())
       .then((data: Record<string, { enabled: boolean; config: Record<string, string> }>) => {
         const active = AVAILABLE_INTEGRATIONS.map((integ) => ({
@@ -114,7 +114,7 @@ function IntegrationsPage() {
     setSaving(true)
     try {
       const apiUrl = getApiUrl()
-      await fetch(`${apiUrl}/meta/integrations/${integId}`, {
+      await apiFetch(`${apiUrl}/meta/integrations/${integId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled: true, config: configValues }),
@@ -133,7 +133,7 @@ function IntegrationsPage() {
   const toggle = async (integId: string, enabled: boolean) => {
     try {
       const apiUrl = getApiUrl()
-      await fetch(`${apiUrl}/meta/integrations/${integId}`, {
+      await apiFetch(`${apiUrl}/meta/integrations/${integId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled }),

--- a/apps/dashboard-neo/src/routes/playground.tsx
+++ b/apps/dashboard-neo/src/routes/playground.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { useState, useEffect } from "react"
 import { FlaskConical } from "lucide-react"
 import { useSocket } from "@/lib/hooks/use-socket"
-import { getApiUrl } from "@/lib/api-client"
+import { apiFetch, getApiUrl } from "@/lib/api-client"
 
 export const Route = createFileRoute("/playground")({ component: PlaygroundPage })
 
@@ -26,7 +26,7 @@ function PlaygroundPage() {
   // Fetch available methods
   useEffect(() => {
     if (!connected) return
-    fetch(`${getApiUrl()}/meta/swagger.json`)
+    apiFetch(`${getApiUrl()}/meta/swagger.json`)
       .then((r) => r.json())
       .then((spec: any) => {
         const defs: MethodDef[] = Object.entries(spec.paths || {}).map(([path, methods]: [string, any]) => {

--- a/apps/dashboard-neo/src/routes/plugins.$name.tsx
+++ b/apps/dashboard-neo/src/routes/plugins.$name.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { Plug, Puzzle, FileText } from "lucide-react"
+import { apiFetch } from "@/lib/api-client"
 
 interface PluginPageData {
   name: string
@@ -38,7 +39,7 @@ function PluginPageRoute() {
       try {
         setLoading(true)
         const base = (window as unknown as { __OPENWA_API_BASE__?: string }).__OPENWA_API_BASE__ ?? ""
-        const res = await fetch(`${base}/plugins/manifest`)
+        const res = await apiFetch(`${base}/plugins/manifest`)
         if (!res.ok) {
           setError("Failed to fetch plugin manifest")
           return

--- a/apps/dashboard-neo/src/types/qrcode.d.ts
+++ b/apps/dashboard-neo/src/types/qrcode.d.ts
@@ -1,0 +1,10 @@
+declare module "qrcode" {
+  export function toDataURL(
+    text: string,
+    options?: {
+      width?: number
+      margin?: number
+      errorCorrectionLevel?: "L" | "M" | "Q" | "H"
+    }
+  ): Promise<string>
+}

--- a/packages/api/src/auth/api-key.ts
+++ b/packages/api/src/auth/api-key.ts
@@ -1,25 +1,19 @@
 import type { Context, Next } from 'hono';
-import { applyDeprecationHeaders } from '../compat/deprecation';
+import { timingSafeEqual } from 'node:crypto';
+
+function apiKeysMatch(candidate: string, expected: string): boolean {
+  const candidateBuffer = Buffer.from(candidate);
+  const expectedBuffer = Buffer.from(expected);
+
+  return candidateBuffer.length === expectedBuffer.length
+    && timingSafeEqual(candidateBuffer, expectedBuffer);
+}
 
 export function apiKeyMiddleware(apiKey: string) {
   return async (c: Context, next: Next) => {
-    const queryKey = c.req.query('api_key') || c.req.query('key');
-    const headerKey =
-      c.req.header('X-API-Key') ||
-      c.req.header('api_key') ||
-      c.req.header('key');
+    const resolvedKey = c.req.header('X-API-Key');
 
-    const resolvedKey = queryKey || headerKey;
-
-    if (c.req.query('api_key') || c.req.query('key') || c.req.header('api_key') || c.req.header('key')) {
-      applyDeprecationHeaders(c, {
-        route: 'legacy-api-key-alias',
-        message: 'Legacy API key aliases are deprecated.',
-        replacement: 'X-API-Key header',
-      });
-    }
-
-    if (!resolvedKey || resolvedKey !== apiKey) {
+    if (!resolvedKey || !apiKeysMatch(resolvedKey, apiKey)) {
       return c.json({ error: 'Unauthorized', details: 'Invalid or missing API key' }, 401);
     }
 

--- a/packages/api/src/createApiServer.ts
+++ b/packages/api/src/createApiServer.ts
@@ -26,6 +26,8 @@ import {
 import type { ApiServerOptions, ClientMethodMap } from './types';
 import type { IScreencastPage } from '@open-wa/screencaster/server';
 import type { PluginHost } from '@open-wa/core';
+import { apiKeyMiddleware } from './auth/api-key';
+import { rateLimitMiddleware } from './middleware/rate-limit';
 
 function parseCorsOrigin(corsConfig: string | string[]): string | string[] {
   if (corsConfig === '*') {
@@ -41,6 +43,20 @@ function parseCorsOrigin(corsConfig: string | string[]): string | string[] {
   }
 
   return corsConfig;
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || normalized.startsWith('127.');
+}
+
+function isPublicRoute(method: string, path: string): boolean {
+  return method === 'OPTIONS'
+    || path === '/health/live'
+    || path === '/dashboard'
+    || path.startsWith('/dashboard/');
 }
 
 export class ApiServer {
@@ -70,6 +86,12 @@ export class ApiServer {
 
   constructor(options: ApiServerOptions) {
     this.config = options.config;
+
+    if (!this.config.apiKey && !isLoopbackHost(this.config.host)) {
+      throw new Error(
+        'Refusing to expose Easy API on a non-loopback host without apiKey.',
+      );
+    }
 
     // Validate MCP configuration
     if (this.config.mcp?.enabled && !this.config.apiKey) {
@@ -261,13 +283,39 @@ export class ApiServer {
   }
 
   private setupMiddleware() {
+    this.app.use('/*', rateLimitMiddleware(300, 60_000));
+
+    this.app.use('/*', async (c, next) => {
+      c.header('Cache-Control', 'no-store');
+      c.header('Content-Security-Policy', "default-src 'self'; base-uri 'none'; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'");
+      c.header('Cross-Origin-Opener-Policy', 'same-origin');
+      c.header('Cross-Origin-Resource-Policy', 'same-origin');
+      c.header('Permissions-Policy', 'camera=(), geolocation=(), microphone=(), payment=(), usb=()');
+      c.header('Referrer-Policy', 'no-referrer');
+      c.header('X-Content-Type-Options', 'nosniff');
+      c.header('X-Frame-Options', 'DENY');
+      await next();
+    });
+
     this.app.use(
       '/*',
       cors({
         origin: parseCorsOrigin(this.config.cors),
-        credentials: true,
+        allowHeaders: ['Content-Type', 'X-API-Key'],
+        credentials: false,
       }),
     );
+
+    if (this.config.apiKey) {
+      const requireApiKey = apiKeyMiddleware(this.config.apiKey);
+      this.app.use('/*', async (c, next) => {
+        const path = new URL(c.req.url).pathname;
+        if (isPublicRoute(c.req.method, path)) {
+          return next();
+        }
+        return requireApiKey(c, next);
+      });
+    }
 
     this.app.use('/*', async (c, next) => {
       const path = new URL(c.req.url).pathname;
@@ -311,6 +359,8 @@ export class ApiServer {
       c.json(this.pluginHost?.getManifest() ?? { plugins: [] }),
     );
 
+    this.app.get('/health/live', (c) => c.json({ status: 'ok' }));
+
     this.app.get('/health', (c) => {
       const healthSnapshot = this.healthStore.getSnapshot();
       return c.json({
@@ -347,8 +397,6 @@ export class ApiServer {
           blockers: [],
           exposureSafe: false,
         },
-        // QR code for pre-launch scanning
-        qr: this.latestQR ?? null,
         // Accumulated health data for the dashboard
         launchTimeline: healthSnapshot.launchTimeline,
         patches: healthSnapshot.patches,
@@ -381,23 +429,6 @@ export class ApiServer {
     });
 
     this.app.get('/api/events', (c) => {
-      // TODO: Unify this inline auth check with the shared apiKeyMiddleware used across Easy API.
-      // Note: This intentionally supports query params to preserve legacy Easy API behavior,
-      // unlike the MCP adapter which strictly enforces header-only auth (X-API-Key) for security.
-      if (this.config.apiKey) {
-        const apiKey =
-          c.req.header('X-API-Key') ||
-          c.req.query('api_key') ||
-          c.req.query('key');
-
-        if (!apiKey || apiKey !== this.config.apiKey) {
-          return c.json(
-            { error: 'Unauthorized', details: 'Invalid or missing API key' },
-            401,
-          );
-        }
-      }
-
       const topicsParam = c.req.query('topics');
       const topics = topicsParam
         ? topicsParam

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -1,26 +1,19 @@
 import type { Context, Next } from 'hono';
 
-const requests = new Map<string, number[]>();
-
-function getRequestKey(_c: Context): string {
-  // The standalone server has no trusted-proxy boundary, so client-supplied
-  // forwarding headers cannot safely identify callers. A process-wide bucket
-  // is conservative and cannot be bypassed by spoofing X-Forwarded-For.
-  return 'global';
-}
-
 export function rateLimitMiddleware(maxRequests = 100, windowMs = 60000) {
-  return async (c: Context, next: Next) => {
-    const requestKey = getRequestKey(c);
-    const now = Date.now();
-    const recentRequests = (requests.get(requestKey) || []).filter((time) => now - time < windowMs);
+  let requests: number[] = [];
 
-    if (recentRequests.length >= maxRequests) {
+  return async (c: Context, next: Next) => {
+    const now = Date.now();
+    requests = requests.filter((time) => now - time < windowMs);
+
+    if (requests.length >= maxRequests) {
       return c.json({ error: 'Too Many Requests', details: 'Rate limit exceeded' }, 429);
     }
 
-    recentRequests.push(now);
-    requests.set(requestKey, recentRequests);
+    // The standalone server has no trusted-proxy boundary. A per-server
+    // bucket cannot be bypassed with client-supplied forwarding headers.
+    requests.push(now);
 
     return await next();
   };

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -2,14 +2,11 @@ import type { Context, Next } from 'hono';
 
 const requests = new Map<string, number[]>();
 
-function getRequestKey(c: Context): string {
-  const forwarded = c.req.header('x-forwarded-for');
-
-  if (forwarded) {
-    return forwarded.split(',')[0].trim();
-  }
-
-  return c.req.header('x-real-ip') || 'unknown';
+function getRequestKey(_c: Context): string {
+  // The standalone server has no trusted-proxy boundary, so client-supplied
+  // forwarding headers cannot safely identify callers. A process-wide bucket
+  // is conservative and cannot be bypassed by spoofing X-Forwarded-For.
+  return 'global';
 }
 
 export function rateLimitMiddleware(maxRequests = 100, windowMs = 60000) {

--- a/packages/api/src/routes/meta.ts
+++ b/packages/api/src/routes/meta.ts
@@ -62,9 +62,6 @@ function renderExplorerHtml(config: Config, methodDefinitions: HttpMethodDefinit
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>open-wa API Explorer — ${config.sessionId}</title>
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
       <style>
         :root {
           --bg: #faf6f0;

--- a/packages/api/test/mcp-integration.test.ts
+++ b/packages/api/test/mcp-integration.test.ts
@@ -3,13 +3,15 @@ import { createApiServer } from '../src/createApiServer.js';
 import { serve } from '@hono/node-server';
 import type { Config } from '@open-wa/config';
 
+const AUTH_HEADERS = { 'X-API-Key': 'test' };
+
 describe('MCP API Integration', () => {
   it('exposes MCP capabilities in /health when disabled', async () => {
     const config: Config = { sessionName: 'test', apiKey: 'test', cors: '*' };
     const apiServer = createApiServer(config);
     const app = apiServer.getApp();
 
-    const res = await app.request('/health');
+    const res = await app.request('/health', { headers: AUTH_HEADERS });
     expect(res.status).toBe(200);
     const data = (await res.json()) as any;
     expect(data.capabilities).toBeDefined();
@@ -28,7 +30,7 @@ describe('MCP API Integration', () => {
     const apiServer = createApiServer(config);
     const app = apiServer.getApp();
 
-    const res = await app.request('/health');
+    const res = await app.request('/health', { headers: AUTH_HEADERS });
     expect(res.status).toBe(200);
     const data = (await res.json()) as any;
     expect(data.capabilities).toBeDefined();
@@ -47,7 +49,7 @@ describe('MCP API Integration', () => {
     const apiServer = createApiServer(config);
     const app = apiServer.getApp();
 
-    const res = await app.request('/meta/mcp-tools.json');
+    const res = await app.request('/meta/mcp-tools.json', { headers: AUTH_HEADERS });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.endpoint).toBe('/mcp');
@@ -65,7 +67,7 @@ describe('MCP API Integration', () => {
     const apiServer = createApiServer(config);
     const app = apiServer.getApp();
 
-    const res = await app.request('/meta/mcp-tools.json');
+    const res = await app.request('/meta/mcp-tools.json', { headers: AUTH_HEADERS });
     expect(res.status).toBe(404);
   });
 

--- a/packages/api/test/rate-limit.test.ts
+++ b/packages/api/test/rate-limit.test.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { rateLimitMiddleware } from '../src/middleware/rate-limit.js';
+
+describe('rateLimitMiddleware', () => {
+  it('cannot be bypassed with spoofed forwarding headers', async () => {
+    const app = new Hono();
+    app.use('/*', rateLimitMiddleware(2, 60_000));
+    app.get('/health/live', (c) => c.json({ status: 'ok' }));
+
+    const first = await app.request('/health/live', {
+      headers: { 'X-Forwarded-For': '198.51.100.1' },
+    });
+    const second = await app.request('/health/live', {
+      headers: { 'X-Forwarded-For': '198.51.100.2' },
+    });
+    const blocked = await app.request('/health/live', {
+      headers: { 'X-Forwarded-For': '198.51.100.3' },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(blocked.status).toBe(429);
+  });
+});

--- a/packages/core/src/transport/Transport.ts
+++ b/packages/core/src/transport/Transport.ts
@@ -153,6 +153,8 @@ const DOCUMENT_READY_CHECK_SCRIPT = `!!(
   || document.readyState === 'complete'
 )`;
 
+type RuntimeMutationKind = 'runtime_install' | 'runtime_recovery';
+
 const RUNTIME_REPLACEMENT_OBSERVER_SCRIPT = `(() => {
   const root = globalThis;
   const existingState = root.__OPENWA_RUNTIME_REPLACEMENT_OBSERVER__;
@@ -204,7 +206,19 @@ const RUNTIME_REPLACEMENT_OBSERVER_SCRIPT = `(() => {
       }
       currentValue = value;
 
-      if (previous && value && previous !== value) {
+      const lease = root.__OPENWA_RUNTIME_MUTATION_LEASE__;
+      const leaseActive = Boolean(
+        lease
+        && typeof lease.token === 'string'
+        && typeof lease.expiresAt === 'number'
+        && lease.expiresAt > Date.now()
+      );
+
+      if (lease && !leaseActive) {
+        delete root.__OPENWA_RUNTIME_MUTATION_LEASE__;
+      }
+
+      if (previous && value && previous !== value && !leaseActive) {
         notifyRuntimeReplacement();
       }
     },
@@ -405,6 +419,8 @@ const LIVE_PATCH_CACHE_FILENAME = 'patches.cache.json';
 const LIVE_PATCH_CACHE_MAX_AGE_MS = 86_400_000;
 /** Maximum consecutive recovery attempts before giving up */
 const MAX_CONSECUTIVE_RECOVERY_ATTEMPTS = 5;
+/** Safety expiry for a page-side lease covering intentional WAPI replacement. */
+const RUNTIME_MUTATION_LEASE_TTL_MS = 15_000;
 
 export class Transport {
   private static assetScriptCache = new Map<string, Promise<string>>();
@@ -445,6 +461,8 @@ export class Transport {
   private latestRuntimeRecoveryRequestId = 0;
   private pendingRuntimeRecoveryCount = 0;
   private consecutiveRecoveryAttempts = 0;
+  private readonly queuedRuntimeRecoveryKeys = new Set<string>();
+  private runtimeMutationLeaseSequence = 0;
   /** Cached live patch scripts for re-application during recovery */
   private cachedLivePatchScripts: string[] = [];
   private frameNavCounter = 0;
@@ -2439,6 +2457,22 @@ export class Transport {
     trigger: 'main_frame_navigation' | 'runtime_replaced',
     generation?: GenerationSnapshot,
   ): void {
+    const targetGeneration = generation ?? this.injectionController.captureGenerationSnapshot();
+    const recoveryKey = [
+      trigger,
+      targetGeneration.documentId,
+      targetGeneration.runtimeId ?? 'no-runtime',
+    ].join(':');
+
+    if (this.queuedRuntimeRecoveryKeys.has(recoveryKey)) {
+      this.logger.debug('runtime_recovery_coalesced', {
+        trigger,
+        recoveryKey,
+      });
+      return;
+    }
+
+    this.queuedRuntimeRecoveryKeys.add(recoveryKey);
     const requestId = ++this.latestRuntimeRecoveryRequestId;
     this.pendingRuntimeRecoveryCount += 1;
 
@@ -2449,8 +2483,8 @@ export class Transport {
     });
 
     this.runtimeRecoveryQueue = this.runtimeRecoveryQueue.then(
-      () => this.runRuntimeRecovery({ requestId, trigger, generation }),
-      () => this.runRuntimeRecovery({ requestId, trigger, generation }),
+      () => this.runRuntimeRecovery({ requestId, trigger, generation: targetGeneration, recoveryKey }),
+      () => this.runRuntimeRecovery({ requestId, trigger, generation: targetGeneration, recoveryKey }),
     ).catch((error) => {
       this.logger.warn('runtime_recovery_failed', {
         trigger,
@@ -2467,7 +2501,8 @@ export class Transport {
   private async runRuntimeRecovery(request: {
     requestId: number;
     trigger: 'main_frame_navigation' | 'runtime_replaced';
-    generation?: GenerationSnapshot;
+    generation: GenerationSnapshot;
+    recoveryKey: string;
   }): Promise<void> {
     try {
       if (!this.page) {
@@ -2555,11 +2590,21 @@ export class Transport {
         }
       }
 
-      const { reinjected } = await this.recoverRuntimeForCurrentDocument({
+      const { capability, reinjected } = await this.recoverRuntimeForCurrentDocument({
         trigger: request.trigger,
         shouldContinue: () => this.isLatestRuntimeRecoveryRequest(request.requestId),
         forceReinject: request.trigger === 'runtime_replaced',
       });
+
+      if (!this.isLatestRuntimeRecoveryRequest(request.requestId)) {
+        return;
+      }
+
+      if (!capability.hasRuntime || (capability.sessionLoaded && !capability.hasStoreMsg)) {
+        throw new Error(
+          `Runtime recovery postconditions failed: ${JSON.stringify(capability)}`,
+        );
+      }
 
       this.logger.info('runtime_recovery_completed', {
         trigger: request.trigger,
@@ -2572,6 +2617,7 @@ export class Transport {
       this.consecutiveRecoveryAttempts = 0;
     } finally {
       this.pendingRuntimeRecoveryCount = Math.max(0, this.pendingRuntimeRecoveryCount - 1);
+      this.queuedRuntimeRecoveryKeys.delete(request.recoveryKey);
     }
   }
 
@@ -2619,7 +2665,7 @@ export class Transport {
 
     // ── Step 1: Reinject wapi.js + launch.js + cached live patches ──
     // performRuntimeInjection already re-applies cached live patch scripts.
-    const reinjected = await this.performRuntimeInjection(shouldContinue);
+    const reinjected = await this.performRuntimeInjection(shouldContinue, 'runtime_recovery');
     if (!shouldContinue()) {
       capability = await this.probeRuntimeCapability();
       return { capability, reinjected };
@@ -2679,7 +2725,17 @@ export class Transport {
     };
   }
 
-  private async performRuntimeInjection(shouldContinue: () => boolean = () => true): Promise<boolean> {
+  private async performRuntimeInjection(
+    shouldContinue: () => boolean = () => true,
+    mutationKind: RuntimeMutationKind = 'runtime_install',
+  ): Promise<boolean> {
+    return this.withRuntimeMutationLease(
+      mutationKind,
+      () => this.performRuntimeInjectionUnderLease(shouldContinue),
+    );
+  }
+
+  private async performRuntimeInjectionUnderLease(shouldContinue: () => boolean): Promise<boolean> {
     if (!this.page) {
       throw new Error('Transport not initialized');
     }
@@ -2761,6 +2817,51 @@ export class Transport {
     }
 
     return success;
+  }
+
+  private async withRuntimeMutationLease<T>(
+    kind: RuntimeMutationKind,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    if (!this.page) {
+      throw new Error('Transport not initialized');
+    }
+
+    const page = this.page;
+    const generation = this.injectionController.captureGenerationSnapshot();
+    const token = `${generation.documentId}:${++this.runtimeMutationLeaseSequence}:${Date.now()}`;
+    const startedAt = Date.now();
+
+    await page.evaluate((lease) => {
+      const root = globalThis as typeof globalThis & {
+        __OPENWA_RUNTIME_MUTATION_LEASE__?: typeof lease;
+      };
+      root.__OPENWA_RUNTIME_MUTATION_LEASE__ = lease;
+    }, {
+      token,
+      kind,
+      documentId: generation.documentId,
+      startedAt,
+      expiresAt: startedAt + RUNTIME_MUTATION_LEASE_TTL_MS,
+    });
+
+    try {
+      return await task();
+    } finally {
+      await page.evaluate((expectedToken) => {
+        const root = globalThis as typeof globalThis & {
+          __OPENWA_RUNTIME_MUTATION_LEASE__?: { token?: string };
+        };
+        if (root.__OPENWA_RUNTIME_MUTATION_LEASE__?.token === expectedToken) {
+          delete root.__OPENWA_RUNTIME_MUTATION_LEASE__;
+        }
+      }, token).catch((error) => {
+        this.logger.debug('runtime_mutation_lease_release_failed', {
+          kind,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
   }
 
   private async probeBrokenMethodIntegrity(): Promise<RuntimeMethodIntegrityResult> {

--- a/packages/core/test/unit/runtimeEventBridge.test.ts
+++ b/packages/core/test/unit/runtimeEventBridge.test.ts
@@ -84,8 +84,10 @@ class RuntimeBridgePage implements IPage {
     }),
   };
   private currentUrl = 'about:blank';
+  private readonly overwriteRuntimeDuringWapiEvaluation: boolean;
 
-  constructor() {
+  constructor(options: { overwriteRuntimeDuringWapiEvaluation?: boolean } = {}) {
+    this.overwriteRuntimeDuringWapiEvaluation = options.overwriteRuntimeDuringWapiEvaluation ?? false;
     this.browserGlobals = {
       WAPI: {
         onAnyMessage: this.wapiRegisterSpies.onAnyMessage,
@@ -101,6 +103,7 @@ class RuntimeBridgePage implements IPage {
       isSessionLoaded: () => true,
       WA_AUTHENTICATED: true,
       __OPENWA_RUNTIME_BRIDGE__: undefined,
+      __OPENWA_RUNTIME_MUTATION_LEASE__: undefined,
     };
   }
 
@@ -169,7 +172,11 @@ class RuntimeBridgePage implements IPage {
       ) as Ret;
     }
 
-    this.restoreRuntime();
+    if (this.overwriteRuntimeDuringWapiEvaluation && _script.includes('window.WAPI = {}')) {
+      this.replaceRuntime();
+    } else {
+      this.restoreRuntime();
+    }
 
     return undefined as Ret;
   }
@@ -329,7 +336,15 @@ class RuntimeBridgePage implements IPage {
         const previous = currentValue;
         currentValue = value;
 
-        if (previous && value && previous !== value) {
+        const lease = this.browserGlobals.__OPENWA_RUNTIME_MUTATION_LEASE__;
+        const leaseActive = Boolean(
+          lease
+          && typeof lease.token === 'string'
+          && typeof lease.expiresAt === 'number'
+          && lease.expiresAt > Date.now()
+        );
+
+        if (previous && value && previous !== value && !leaseActive) {
           void Promise.resolve(this.browserGlobals.OpenWA_RuntimeReplacementDetected?.({ reason: 'runtime_replaced' }));
         }
       },
@@ -389,6 +404,30 @@ function createLogger(): Logger {
 }
 
 describe('Transport runtime event bridge', () => {
+  it('does not treat the wapi asset replacing its own runtime as an external replacement', async () => {
+    const page = new RuntimeBridgePage({ overwriteRuntimeDuringWapiEvaluation: true });
+    const logger = createLogger();
+    const transport = new Transport({
+      driver: new FakeDriver(new FakeBrowser(page)),
+      events: new HyperEmitter<OpenWAEventMap>({ delimiter: '.', captureRejections: true }),
+      logger,
+      headless: true,
+      blockCrashLogs: false,
+      blockAssets: false,
+    });
+
+    await transport.initialize();
+    await transport.injectWapi();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'runtime_recovery_queued',
+      expect.anything(),
+    );
+    expect(page.browserGlobals.WAPI).toBeTruthy();
+    expect(page.wapiRegisterSpies.onStateChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('maps browser runtime callbacks onto core events and avoids duplicate setup in the same generation', async () => {
     const page = new RuntimeBridgePage();
     const events = new HyperEmitter<OpenWAEventMap>({ delimiter: '.', captureRejections: true });
@@ -533,5 +572,35 @@ describe('Transport runtime event bridge', () => {
     expect(page.waitForFunctionCalls).toEqual(expect.arrayContaining([
       expect.stringContaining('document.readyState'),
     ]));
+  });
+
+  it('coalesces rapid duplicate replacement notifications for the same runtime generation', async () => {
+    const page = new RuntimeBridgePage();
+    const logger = createLogger();
+    const transport = new Transport({
+      driver: new FakeDriver(new FakeBrowser(page)),
+      events: new HyperEmitter<OpenWAEventMap>({ delimiter: '.', captureRejections: true }),
+      logger,
+      headless: true,
+      blockCrashLogs: false,
+      blockAssets: false,
+    });
+
+    await transport.initialize();
+    await transport.injectWapi();
+
+    page.replaceRuntime();
+    page.replaceRuntime();
+    page.replaceRuntime();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const queuedCalls = vi.mocked(logger.warn).mock.calls.filter(
+      ([message]) => message === 'runtime_recovery_queued',
+    );
+    expect(queuedCalls).toHaveLength(1);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'runtime_recovery_coalesced',
+      expect.anything(),
+    );
   });
 });

--- a/packages/socket-client/src/SocketClient.ts
+++ b/packages/socket-client/src/SocketClient.ts
@@ -361,25 +361,15 @@ export class SocketClient {
             this.resolveStreamOpen = resolve;
             this.rejectStreamOpen = reject;
 
-            let EventSourceCtor: any;
-            try {
-                EventSourceCtor = (globalThis as any).EventSource;
-            } catch {
-                EventSourceCtor = undefined;
-            }
-
-            if (!EventSourceCtor) {
-                EventSourceCtor = EventSourcePolyfill;
-            }
-
-            if (!EventSourceCtor) {
-                const error = new Error('EventSource is not available in this runtime');
-                this.streamOpenPromise = null;
-                reject(error);
-                return;
-            }
-
-            const stream = new EventSourceCtor(this.getEventsUrl());
+            const stream = new EventSourcePolyfill(this.getEventsUrl(), this.apiKey
+                ? {
+                    fetch: (input, init) => {
+                        const headers = new Headers(init?.headers);
+                        headers.set('X-API-Key', this.apiKey);
+                        return fetch(input, { ...init, headers });
+                    },
+                }
+                : undefined);
             this.stream = stream;
             this.boundStreamEvents.clear();
 
@@ -630,9 +620,6 @@ export class SocketClient {
     private getEventsUrl(): string {
         const parsed = new URL(`${this.getBaseUrl()}/api/events`);
         parsed.searchParams.set('topics', '*');
-        if (this.apiKey) {
-            parsed.searchParams.set('api_key', this.apiKey);
-        }
         return parsed.toString();
     }
 }

--- a/packages/wa-automate/src/server/__tests__/middleware.test.ts
+++ b/packages/wa-automate/src/server/__tests__/middleware.test.ts
@@ -67,6 +67,59 @@ describe('Hono Middleware', () => {
       });
     });
 
+    it('protects operational endpoints with header-only authentication', async () => {
+      const apiKey = 'privacy-first-test-key-32-bytes';
+      const config = ConfigSchema.parse({
+        sessionId: 'test',
+        host: '0.0.0.0',
+        port: 8011,
+        apiKey,
+      });
+      const server = new WAServer(config);
+      server.setQR('sensitive-qr-payload');
+
+      const liveResponse = await server.getApp().request('/health/live');
+      expect(liveResponse.status).toBe(200);
+      await expect(liveResponse.json()).resolves.toEqual({ status: 'ok' });
+
+      for (const path of ['/health', '/qr', '/plugins/manifest', '/meta/debug/config']) {
+        const unauthenticated = await server.getApp().request(path);
+        expect(unauthenticated.status).toBe(401);
+      }
+
+      const queryAuth = await server.getApp().request(`/health?api_key=${apiKey}`);
+      expect(queryAuth.status).toBe(401);
+
+      const authenticatedHealth = await server.getApp().request('/health', {
+        headers: { 'X-API-Key': apiKey },
+      });
+      expect(authenticatedHealth.status).toBe(200);
+      const healthBody = (await authenticatedHealth.json()) as Record<string, unknown>;
+      expect(healthBody).not.toHaveProperty('qr');
+      expect(authenticatedHealth.headers.get('cache-control')).toBe('no-store');
+      expect(authenticatedHealth.headers.get('x-frame-options')).toBe('DENY');
+
+      const authenticatedQr = await server.getApp().request('/qr', {
+        headers: { 'X-API-Key': apiKey },
+      });
+      expect(authenticatedQr.status).toBe(200);
+      await expect(authenticatedQr.json()).resolves.toMatchObject({
+        qr: 'sensitive-qr-payload',
+      });
+    });
+
+    it('refuses a non-loopback bind without an API key', () => {
+      const config = ConfigSchema.parse({
+        sessionId: 'test',
+        host: '0.0.0.0',
+        port: 8012,
+      });
+
+      expect(() => new WAServer(config)).toThrow(
+        'Refusing to expose Easy API on a non-loopback host without apiKey.',
+      );
+    });
+
     it('should return an empty plugin manifest when no plugins are mounted', async () => {
       const config = ConfigSchema.parse({ sessionId: 'test', port: 8009 });
       const server = new WAServer(config);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(prettier@3.8.1)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.2.4
         version: 19.2.4


### PR DESCRIPTION
## Summary

- require `X-API-Key` for operational, debug, discovery, QR, integration, plugin, screencast, and event endpoints
- reject API keys in URLs and legacy alias headers, compare keys with constant-time equality, and make rate limiting resistant to spoofed forwarding headers
- remove QR data from `/health`, render QR codes locally, remove third-party fonts and browser model-context exposure, and keep dashboard credentials session-only
- add restrictive browser security headers and refuse non-loopback API binds without an API key

## Verification

- `pnpm --filter '@open-wa/wa-automate...' build`
- `pnpm --filter @open-wa/wa-automate exec vitest run src/server/__tests__/middleware.test.ts src/server/__tests__/readiness-parity.test.ts` (9 passed)
- `pnpm --filter @open-wa/api test` (6 passed)
- `pnpm --filter @open-wa/api lint`
- `pnpm --filter @open-wa/socket-client build`
- `pnpm --filter @open-wa/socket-client lint`
- `pnpm --filter @open-wa/dashboard-neo lint`

The dashboard typecheck still reports existing baseline errors in unrelated files. Its production Vite build succeeds as part of the dependency build above.

## Stacking

This is stacked on #3392 because the deployment needs both the runtime recovery fix and the security hardening. Once #3392 lands, this PR can be rebased to show only the privacy/API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API-key configuration in the dashboard for authenticated API and live event connections.
  - Added local QR-code rendering in the dashboard.
  - Added a public liveness health check.

- **Security**
  - API keys are now accepted through request headers instead of URLs.
  - Added security headers, protected operational endpoints, and loopback-host safeguards.
  - Improved rate-limit protection against spoofed client information.

- **Bug Fixes**
  - Improved runtime recovery and reduced duplicate recovery attempts.
  - Removed external font and QR-service dependencies from displayed pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->